### PR TITLE
fix: generate JavaScript object literals in ds_json_signals

### DIFF
--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -208,15 +208,15 @@ def ds_persist(*signals, include=None, exclude=None, session=False, key=None):
 
 
 def ds_json_signals(show=True, include=None, exclude=None, terse=False):
-    key = "data-json-signals" + ("__terse" if terse else "")
+    key = f"data-json-signals{'__terse' if terse else ''}"
 
-    value = (
-        json.dumps({k: _process_patterns(v) for k, v in [("include", include), ("exclude", exclude)] if v})
-        if include or exclude
-        else "false"
-        if show is False
-        else True
-    )
+    if show is False:
+        value = "false"
+    elif include or exclude:
+        filters = [f"{k}: {_process_patterns(v)}" for k, v in [("include", include), ("exclude", exclude)] if v]
+        value = f"{{{', '.join(filters)}}}"
+    else:
+        value = True
 
     return DatastarAttr({key: value})
 

--- a/tests/unit/test_datastar_new_api.py
+++ b/tests/unit/test_datastar_new_api.py
@@ -290,8 +290,10 @@ class TestSignalsAndPersistence:
         # Filters
         result = attrs_of(ds_json_signals(include="user", exclude="temp"))
         data = str(result["data-json-signals"])
-        assert '"/user/"' in data
-        assert '"/temp/"' in data
+        assert "/user/" in data
+        assert "/temp/" in data
+        assert "include:" in data
+        assert "exclude:" in data
 
 
 class TestEventHandlers:


### PR DESCRIPTION
## Summary
- Fixed ds_json_signals to generate JavaScript object literals instead of JSON strings
- Resolved Datastar runtime error "Unexpected token ':'" in 09-attributes demo
- Improved code idiomaticity with f-strings and list comprehensions

## Problem
The ds_json_signals function was generating JSON string attributes like:
```
{"include": "/(counter|Time)/"}
```

This caused Datastar runtime errors because it expects JavaScript expressions that evaluate to objects, not JSON strings.

## Solution
Now generates proper JavaScript object literals:
```
{include: /(counter|Time)/}
```

## Test plan
- [x] All existing tests pass (39/39)
- [x] Quality checks pass (ruff, pyright)  
- [x] Demo server starts without errors
- [x] Manual verification of generated attributes
- [x] Updated test expectations to match new format