### PR TITLE
Fix: bodykw parameter conflict with live reload mode

### DIFF
--- a/src/starhtml/realtime.py
+++ b/src/starhtml/realtime.py
@@ -474,23 +474,25 @@ class StarHTMLWithLiveReload:
     """
 
     def __new__(cls, *args, **kwargs):
-        """
-        Factory using __new__ to dynamically create a StarHTML subclass.
-
-        This pattern is used to inject live-reload routes and headers into the
-        StarHTML application at instantiation time without requiring the user
-        to manually inherit from StarHTML or configure live-reload manually.
-        """
+        """Factory using __new__ to dynamically inject live-reload into StarHTML."""
         from .core import StarHTML
+
+        bodykw = kwargs.pop("bodykw", {})
+        reload_attempts = kwargs.pop("reload_attempts", 1)
+        reload_interval = kwargs.pop("reload_interval", 1000)
 
         class _StarHTMLWithLiveReload(StarHTML):
             def __init__(self, *args, **kwargs):
-                # "hdrs" and "routes" can be missing, None, a list or a tuple.
-                kwargs["hdrs"] = [*(kwargs.get("hdrs") or []), LiveReloadJs(**kwargs)]
+                kwargs["hdrs"] = [
+                    *(kwargs.get("hdrs") or []),
+                    LiveReloadJs(reload_attempts=reload_attempts, reload_interval=reload_interval),
+                ]
                 kwargs["routes"] = [
                     *(kwargs.get("routes") or []),
                     WebSocketRoute("/live-reload", endpoint=live_reload_ws),
                 ]
+                if bodykw:
+                    kwargs.update(bodykw)
                 super().__init__(*args, **kwargs)
 
         return _StarHTMLWithLiveReload(*args, **kwargs)

--- a/src/starhtml/starapp.py
+++ b/src/starhtml/starapp.py
@@ -83,11 +83,11 @@ def star_app(
         key_fname=key_fname,
         exts=exts,
         htmlkw=htmlkw,
+        bodykw=bodykw,
         reload_attempts=reload_attempts,
         reload_interval=reload_interval,
         body_wrap=body_wrap,
         auto_unpack=auto_unpack,
-        **(bodykw or {}),
     )
     app.static_route_exts(static_path=static_path)
 
@@ -177,6 +177,10 @@ def _app_factory(*args, **kwargs):
 
     if kwargs.pop("live", False):
         return StarHTMLWithLiveReload(*args, **kwargs)
+
     kwargs.pop("reload_attempts", None)
     kwargs.pop("reload_interval", None)
+    bodykw = kwargs.pop("bodykw", {})
+    if bodykw:
+        kwargs.update(bodykw)
     return StarHTML(*args, **kwargs)

--- a/tests/unit/test_bodykw_fix.py
+++ b/tests/unit/test_bodykw_fix.py
@@ -1,0 +1,32 @@
+"""Test bodykw parameter handling with live reload."""
+
+from src.starhtml.starapp import star_app
+
+
+class TestBodyKw:
+    def test_bodykw_without_live(self):
+        app, _ = star_app(bodykw={"cls": "test-class"})
+        assert app.bodykw == {"cls": "test-class"}
+
+    def test_bodykw_with_live(self):
+        app, _ = star_app(live=True, bodykw={"cls": "test-class"})
+        assert app.bodykw == {"cls": "test-class"}
+
+    def test_complex_bodykw_with_live(self):
+        attrs = {"cls": "min-h-screen bg-background", "id": "app-body", "data-theme": "light"}
+        app, _ = star_app(live=True, bodykw=attrs)
+        assert app.bodykw == attrs
+
+    def test_empty_bodykw(self):
+        app1, _ = star_app(bodykw={})
+        app2, _ = star_app(live=True, bodykw={})
+        assert app1.bodykw == app2.bodykw == {}
+
+    def test_none_bodykw(self):
+        app1, _ = star_app()
+        app2, _ = star_app(live=True)
+        assert app1.bodykw == app2.bodykw == {}
+
+    def test_bodykw_with_debug(self):
+        app, _ = star_app(live=True, debug=True, bodykw={"cls": "custom-body-class"})
+        assert app.bodykw == {"cls": "custom-body-class"}


### PR DESCRIPTION
Fixes TypeError when using `bodykw` parameter with `live=True` in star_app().

## Problem
When `live=True` is set, bodykw parameters were incorrectly spread into kwargs, causing conflicts with StarHTMLWithLiveReload's __new__ method.

## Solution  
- Extract bodykw before passing to StarHTML to avoid parameter conflicts
- Ensure reload_attempts and reload_interval don't leak into bodykw
- Add comprehensive tests for bodykw with and without live mode

## Test
```python
# Previously would crash with TypeError
app, rt = star_app(live=True, bodykw={"cls": "min-h-screen bg-gray-100"})
# Now works correctly
```