### PR TITLE
Fix: Add DatastarAttr to HTMLContent type union

### DIFF
--- a/src/starhtml/types.py
+++ b/src/starhtml/types.py
@@ -4,8 +4,10 @@ from typing import Any, Literal, Protocol, TypeVar
 
 from fastcore.xml import FT
 
+from starhtml.datastar import DatastarAttr
+
 # Core HTML content types
-HTMLContent = str | int | float | FT | None
+HTMLContent = str | int | float | FT | DatastarAttr | None
 HTMLChildren = HTMLContent | tuple[HTMLContent, ...] | list[HTMLContent]
 
 # CSS and style types


### PR DESCRIPTION
## Summary
- Fixes type checking errors when using DatastarAttr objects as HTML element children
- Adds DatastarAttr to the HTMLContent type union in `src/starhtml/types.py`
- Single-line change that makes type hints match runtime behavior

## Problem
DatastarAttr objects work perfectly at runtime but caused false-positive type errors in IDEs with type checking enabled (VSCode with Pylance, pyright, mypy, etc).

## Solution
Added `DatastarAttr` to the `HTMLContent` type union, allowing it to be recognized as a valid child type for HTML elements.

## Testing
- ✅ All existing tests pass
- ✅ Type checking with pyright shows 0 errors
- ✅ Ruff linting and formatting checks pass
- ✅ Runtime behavior unchanged (fully backwards compatible)

## Example
```python
from starhtml import Span, Div
from starhtml.datastar import ds_show, ds_on_click

# Previously showed type errors, now works correctly:
element = Span(
    "Hello",
    ds_show("$visible")  # No more type error\!
)

container = Div(
    Span("Content"),
    ds_show("$visible"),      # No more type error\!
    ds_on_click("$count++"),  # No more type error\!
    cls="my-class"
)
```

Closes #[issue-number-if-exists]