### PR TITLE
fix: improve datastar attribute handling

### DIFF
--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -9,13 +9,25 @@ from fastcore.xml import NotStr
 
 
 class DatastarAttr:
-    """Wrapper that enables flat API usage without ** unpacking."""
+    """Wrapper that enables both .attrs access and direct ** unpacking."""
 
     def __init__(self, attrs):
         self.attrs = attrs
 
     def __repr__(self):
         return f"DatastarAttr({self.attrs})"
+
+    def keys(self):
+        return self.attrs.keys()
+
+    def __getitem__(self, key):
+        return self.attrs[key]
+
+    def __iter__(self):
+        return iter(self.attrs)
+
+    def __len__(self):
+        return len(self.attrs)
 
 
 def t(template: str) -> str:
@@ -187,6 +199,10 @@ def ds_computed(name: str, expression: str, case: str | None = None) -> Datastar
 
 def _make_attr_func(prefix: str):
     def attr_func(**kwargs) -> DatastarAttr:
+        if any("/" in str(name) for name in kwargs):
+            attr_dict = {name: _normalize_value(value) for name, value in kwargs.items()}
+            return DatastarAttr({prefix: json.dumps(attr_dict)})
+
         return DatastarAttr(
             {f"{prefix}-{name.replace('_', '-')}": _normalize_value(value) for name, value in kwargs.items()}
         )

--- a/tests/unit/test_datastar_mapping.py
+++ b/tests/unit/test_datastar_mapping.py
@@ -1,0 +1,126 @@
+"""Test that DatastarAttr implements the mapping protocol for unpacking."""
+
+from starhtml.datastar import (
+    DatastarAttr,
+    ds_attr,
+    ds_bind,
+    ds_class,
+    ds_disabled,
+    ds_show,
+    ds_style,
+    ds_text,
+)
+
+
+class TestDatastarAttrMapping:
+    """Test that DatastarAttr can be unpacked with **."""
+
+    def test_datastar_attr_is_mapping(self):
+        """Test that DatastarAttr implements the mapping protocol."""
+        attr = DatastarAttr({"test-key": "test-value"})
+
+        # Test mapping methods
+        assert list(attr.keys()) == ["test-key"]
+        assert len(attr) == 1
+        assert list(attr) == ["test-key"]
+        assert attr["test-key"] == "test-value"
+
+        # Test unpacking
+        unpacked = {**attr}
+        assert unpacked == {"test-key": "test-value"}
+
+        # Test dict() constructor
+        as_dict = dict(attr)
+        assert as_dict == {"test-key": "test-value"}
+
+    def test_ds_disabled_unpacking(self):
+        """Test ds_disabled can be unpacked directly."""
+        # Without unpacking operator should fail previously, but work now
+        result = {**ds_disabled("$condition")}
+        assert result == {"data-attr-disabled": "$condition"}
+
+        # Boolean value
+        result = {**ds_disabled(True)}
+        assert result == {"data-attr-disabled": "true"}
+
+    def test_multiple_ds_functions_unpacking(self):
+        """Test combining multiple ds_* functions with unpacking."""
+        combined = {**ds_disabled("!$isActive"), **ds_class(**{"opacity-50": "$isDisabled"}), **ds_show("$isVisible")}
+
+        assert "data-attr-disabled" in combined
+        assert "data-class-opacity-50" in combined
+        assert "data-show" in combined
+
+    def test_ds_class_unpacking(self):
+        """Test ds_class unpacking with various inputs."""
+        # Regular classes
+        result = {**ds_class(**{"text-blue": "$isBlue", "font-bold": "$isBold"})}
+        assert "data-class-text-blue" in result
+        assert "data-class-font-bold" in result
+
+        # With slashes (uses dictionary format)
+        result = {**ds_class(**{"border-primary/60": "$isPrimary"})}
+        assert "data-class" in result
+        assert "border-primary/60" in result["data-class"]
+
+    def test_all_ds_functions_unpackable(self):
+        """Test that all ds_* functions return unpackable results."""
+        # Test functions that take positional args
+        positional_funcs = [
+            (ds_show, "$visible"),
+            (ds_text, "$message"),
+            (ds_bind, "inputValue"),
+            (ds_disabled, "$isDisabled"),
+        ]
+
+        for func, arg in positional_funcs:
+            result = func(arg)
+            # Should be able to unpack without error
+            unpacked = {**result}
+            assert isinstance(unpacked, dict)
+            assert len(unpacked) > 0
+
+        # Test functions that take keyword args
+        result = ds_style(color="$textColor")
+        unpacked = {**result}
+        assert isinstance(unpacked, dict)
+
+        result = ds_attr(title="$tooltip")
+        unpacked = {**result}
+        assert isinstance(unpacked, dict)
+
+    def test_backward_compatibility(self):
+        """Test that .attrs still works for backward compatibility."""
+        attr = ds_disabled("$condition")
+
+        # Old way with .attrs
+        old_way = attr.attrs
+        assert old_way == {"data-attr-disabled": "$condition"}
+
+        # New way with unpacking
+        new_way = {**attr}
+        assert new_way == {"data-attr-disabled": "$condition"}
+
+        # Both should be identical
+        assert old_way == new_way
+
+    def test_empty_datastar_attr(self):
+        """Test edge case with empty attributes."""
+        attr = DatastarAttr({})
+
+        assert len(attr) == 0
+        assert list(attr.keys()) == []
+        assert {**attr} == {}
+        assert dict(attr) == {}
+
+    def test_multiple_attributes(self):
+        """Test DatastarAttr with multiple attributes."""
+        attr = DatastarAttr({"data-show": "$visible", "data-text": "$message", "data-class-active": "$isActive"})
+
+        assert len(attr) == 3
+        assert set(attr.keys()) == {"data-show", "data-text", "data-class-active"}
+
+        unpacked = {**attr}
+        assert unpacked["data-show"] == "$visible"
+        assert unpacked["data-text"] == "$message"
+        assert unpacked["data-class-active"] == "$isActive"

--- a/tests/unit/test_tailwind_opacity_workarounds.py
+++ b/tests/unit/test_tailwind_opacity_workarounds.py
@@ -1,0 +1,87 @@
+"""Test Tailwind opacity handling with dictionary syntax for StarHTML/Datastar."""
+
+import json
+
+from starhtml import Div
+from starhtml.datastar import ds_class
+
+
+class TestTailwindOpacityHandling:
+    """Test dictionary syntax for Tailwind opacity classes with forward slashes."""
+
+    def test_ds_class_with_slash_uses_dictionary(self):
+        """Test that ds_class uses dictionary syntax when slashes are present."""
+        result = ds_class(**{"border-primary/60": "$isPrimary", "bg-accent/30": "$isActive"})
+
+        # Should use dictionary syntax to preserve slashes
+        expected_dict = {"border-primary/60": "$isPrimary", "bg-accent/30": "$isActive"}
+
+        assert "data-class" in result.attrs
+        assert json.loads(result.attrs["data-class"]) == expected_dict
+
+    def test_ds_class_without_slash_uses_attributes(self):
+        """Test that ds_class uses regular attributes when no slashes."""
+        result = ds_class(**{"text_blue_500": "$isBlue", "hover_bg_gray_100": "$isHover"})
+
+        # Should use regular attribute syntax
+        expected = {"data-class-text-blue-500": "$isBlue", "data-class-hover-bg-gray-100": "$isHover"}
+
+        assert result.attrs == expected
+
+    def test_mixed_classes_with_and_without_slashes(self):
+        """Test mixed classes triggers dictionary mode."""
+        result = ds_class(**{"border-primary/60": "$isPrimary", "text_blue_500": "$isBlue", "bg-white/90": "$isLight"})
+
+        # Should use dictionary for all when any have slashes
+        expected_dict = {"border-primary/60": "$isPrimary", "text_blue_500": "$isBlue", "bg-white/90": "$isLight"}
+
+        assert "data-class" in result.attrs
+        assert json.loads(result.attrs["data-class"]) == expected_dict
+
+    def test_other_ds_functions_with_slashes(self):
+        """Test that other ds_* functions created with _make_attr_func handle slashes."""
+        from starhtml.datastar import ds_attr, ds_style
+
+        # Test ds_style with slash-containing keys
+        style_result = ds_style(**{"width/special": "$widthValue"})
+        assert "data-style" in style_result.attrs
+        assert json.loads(style_result.attrs["data-style"]) == {"width/special": "$widthValue"}
+
+        # Test ds_attr with slash-containing keys
+        attr_result = ds_attr(**{"href/special": "$linkValue"})
+        assert "data-attr" in attr_result.attrs
+        assert json.loads(attr_result.attrs["data-attr"]) == {"href/special": "$linkValue"}
+
+    def test_html_generation_with_opacity_classes(self):
+        """Test HTML generation with Tailwind opacity classes."""
+        element = Div(
+            "Opacity example",
+            **ds_class(
+                **{"border-primary/60": "$isPrimary", "bg-accent/30": "$isActive", "p_4": True, "rounded_lg": True}
+            ),
+        )
+
+        html_str = str(element)
+
+        # Check that dictionary syntax is in HTML
+        assert "data-class=" in html_str
+        assert "border-primary/60" in html_str
+        assert "bg-accent/30" in html_str
+
+    def test_boolean_values_with_slashes(self):
+        """Test boolean values work with slash-containing keys."""
+        result = ds_class(**{"bg-black/50": True, "hover:bg-white/10": False})
+
+        expected_dict = {
+            "bg-black/50": "true",  # Booleans are normalized to strings
+            "hover:bg-white/10": "false",
+        }
+
+        assert "data-class" in result.attrs
+        assert json.loads(result.attrs["data-class"]) == expected_dict
+
+
+if __name__ == "__main__":
+    import pytest
+
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary
- Add dictionary syntax for attributes with slashes (e.g., Tailwind opacity classes like `border-primary/60`)  
- Implement mapping protocol for `DatastarAttr` to enable `**` unpacking

## Test plan
- [x] Unit tests added for slash handling in `test_tailwind_opacity_workarounds.py`
- [x] Unit tests added for mapping protocol in `test_datastar_mapping.py`  
- [x] All existing tests pass
- [x] Code passes linting