### PR TITLE
Fix submenu positioning with configurable offsets

### DIFF
--- a/demo/component-tests/test_position_opacity.py
+++ b/demo/component-tests/test_position_opacity.py
@@ -57,7 +57,7 @@ def PopoverTrigger(*children, variant="default", cls="", **attrs):
     return make_injectable(_inject_signal)
 
 
-def PopoverContent(*children, cls="", side="bottom", align="center", **attrs):
+def PopoverContent(*children, cls="", side="bottom", align="center", offset=None, **attrs):
     def _inject_signal(signal):
         placement = f"{side}-{align}" if align != "center" else side
 
@@ -71,10 +71,21 @@ def PopoverContent(*children, cls="", side="bottom", align="center", **attrs):
 
         processed_children = [process_element(child) for child in children]
 
+        # Build ds_position kwargs with optional offset
+        position_kwargs = {
+            "anchor": f"{signal}-trigger",
+            "placement": placement,
+            "flip": True,
+            "shift": True,
+            "hide": True,
+        }
+        if offset is not None:
+            position_kwargs["offset"] = offset
+
         return Div(
             *processed_children,
             ds_ref(f"{signal}Content"),
-            ds_position(anchor=f"{signal}-trigger", placement=placement, offset=8, flip=True, shift=True, hide=True),
+            ds_position(**position_kwargs),
             popover="auto",
             id=f"{signal}-content",
             role="dialog",
@@ -582,6 +593,102 @@ def home():
                         PopoverClose("✕"),
                         side="bottom",
                         cls="w-48",
+                    ),
+                ),
+                cls="flex gap-4 justify-center flex-wrap",
+            ),
+            cls="test-section",
+        ),
+        # Test 9: Custom Offset Test - Verify user-specified offsets work
+        Div(
+            H2("Test 9: Custom Offset for Submenus", cls="text-xl font-semibold mb-4"),
+            P(
+                "Testing that user-specified offsets override smart defaults",
+                cls="text-gray-600 mb-4",
+            ),
+            Div(
+                # Test with explicit large gap (20px)
+                Popover(
+                    PopoverTrigger(
+                        "Menu with 20px Gap",
+                        cls="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700",
+                    ),
+                    PopoverContent(
+                        H3("20px Gap Test", cls="font-bold mb-3"),
+                        Popover(
+                            PopoverTrigger(
+                                "Submenu with 20px offset →",
+                                cls="w-full text-left px-3 py-2 hover:bg-gray-100 rounded",
+                            ),
+                            PopoverContent(
+                                P("This should have 20px gap", cls="text-sm"),
+                                PopoverClose("✕"),
+                                side="right",
+                                align="start",
+                                offset="20",
+                                cls="w-48 bg-green-50",
+                            ),
+                            cls="w-full",
+                        ),
+                        PopoverClose("✕"),
+                        side="bottom",
+                        cls="w-64",
+                    ),
+                ),
+                # Test with zero offset (touching)
+                Popover(
+                    PopoverTrigger(
+                        "Menu with 0px Gap",
+                        cls="px-4 py-2 bg-yellow-600 text-white rounded hover:bg-yellow-700",
+                    ),
+                    PopoverContent(
+                        H3("0px Gap Test", cls="font-bold mb-3"),
+                        Popover(
+                            PopoverTrigger(
+                                "Submenu with 0px offset →",
+                                cls="w-full text-left px-3 py-2 hover:bg-gray-100 rounded",
+                            ),
+                            PopoverContent(
+                                P("This should be touching", cls="text-sm"),
+                                PopoverClose("✕"),
+                                side="right",
+                                align="start",
+                                offset="0",
+                                cls="w-48 bg-yellow-50",
+                            ),
+                            cls="w-full",
+                        ),
+                        PopoverClose("✕"),
+                        side="bottom",
+                        cls="w-64",
+                    ),
+                ),
+                # Test with negative offset (overlapping more)
+                Popover(
+                    PopoverTrigger(
+                        "Menu with -10px Overlap",
+                        cls="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700",
+                    ),
+                    PopoverContent(
+                        H3("-10px Overlap Test", cls="font-bold mb-3"),
+                        Popover(
+                            PopoverTrigger(
+                                "Submenu with -10px offset →",
+                                cls="w-full text-left px-3 py-2 hover:bg-gray-100 rounded",
+                            ),
+                            PopoverContent(
+                                P("This should overlap by 10px", cls="text-sm"),
+                                PopoverClose("✕"),
+                                side="right",
+                                align="start",
+                                offset="-10",
+                                cls="w-48 bg-red-50",
+                            ),
+                            cls="w-full",
+                        ),
+                        PopoverClose("✕"),
+                        side="bottom",
+                        cls="w-64",
                     ),
                 ),
                 cls="flex gap-4 justify-center flex-wrap",

--- a/typescript/handlers/position.ts
+++ b/typescript/handlers/position.ts
@@ -94,6 +94,7 @@ type PositionConfig = {
   placement: Placement;
   strategy: Strategy;
   offset: number;
+  hasCustomOffset: boolean;
   flip: boolean;
   shift: boolean;
   hide: boolean;
@@ -112,18 +113,22 @@ async function computeFloatingPosition(
   ) as HTMLElement | null;
 
   let offsetValue = config.offset;
+
+  // Submenus need offset relative to parent menu edge, not trigger element
   if (parentPopover) {
-    const isHorizontal =
-      config.placement.startsWith("right") || config.placement.startsWith("left");
-    if (isHorizontal) {
-      const parentRect = parentPopover.getBoundingClientRect();
-      const refRect = reference.getBoundingClientRect();
-      const distanceToEdge = config.placement.startsWith("right")
-        ? parentRect.right - refRect.right
-        : refRect.left - parentRect.left;
-      offsetValue = Math.max(8, distanceToEdge + 8);
-    } else {
-      offsetValue = 12;
+    const parentRect = parentPopover.getBoundingClientRect();
+    const refRect = reference.getBoundingClientRect();
+
+    const edgeDistances = {
+      right: parentRect.right - refRect.right,
+      left: refRect.left - parentRect.left,
+      bottom: parentRect.bottom - refRect.bottom,
+      top: refRect.top - parentRect.top,
+    };
+
+    const edge = config.placement.split("-")[0] as keyof typeof edgeDistances;
+    if (edge in edgeDistances) {
+      offsetValue = edgeDistances[edge] + (config.hasCustomOffset ? config.offset : -2);
     }
   }
 
@@ -228,11 +233,13 @@ export default {
   onLoad({ el, value, mods, startBatch, endBatch }: RuntimeContext): OnRemovalFn | void {
     injectPositioningCSS();
 
+    const offsetValue = extract(mods.get("offset"));
     const config = {
       anchor: extract(mods.get("anchor") || value),
       placement: extractPlacement(mods.get("placement")),
       strategy: (extract(mods.get("strategy")) || "absolute") as Strategy,
-      offset: Number(extract(mods.get("offset"))) || 8,
+      offset: offsetValue ? Number(offsetValue) : 8,
+      hasCustomOffset: !!offsetValue,
       flip: extract(mods.get("flip")) !== "false",
       shift: extract(mods.get("shift")) !== "false",
       hide: extract(mods.get("hide")) === "true",


### PR DESCRIPTION
## Summary
- Fixed submenu positioning to align properly with parent menu edges
- Submenus now have a subtle 2px overlap by default (matching ShadCN/Radix UI)
- User-specified offsets are properly respected

## Changes
- **position.ts**: Calculate submenu offset relative to parent menu edge instead of trigger element
- **test_position_opacity.py**: Added test cases for custom offset scenarios and fixed PopoverContent to accept offset parameter

## Technical Details
The previous implementation calculated offsets relative to the trigger button, causing incorrect positioning for submenus. Now:
- Default behavior: 2px overlap with parent menu edge for visual continuity
- Custom offsets: Properly applied relative to the parent menu edge
- offset="20" creates a 20px gap
- offset="0" creates touching edges
- offset="-10" creates 10px overlap

## Testing
Added Test 9 in test_position_opacity.py with three scenarios to verify custom offsets work correctly.