### PR TITLE
fix: improve t() and toggle_class() helper functions

### DIFF
--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -31,7 +31,18 @@ class DatastarAttr:
 
 
 def t(template: str) -> str:
-    """JavaScript template literal using Python f-string style."""
+    """JavaScript template literal from Python string or variable.
+
+    t("myVar") -> `${myVar}`
+    t("{name}") -> `${name}`
+    t("Hello {name}") -> `Hello ${name}`
+    """
+    if re.match(r"^[$]?[a-zA-Z_]\w*$", template):
+        return f"`${{{template.lstrip('$')}}}`"
+
+    if "${" in template:
+        return f"`{template}`"
+
     return f"`{re.sub(r'{([^}]+)}', r'${\1}', template)}`"
 
 
@@ -502,18 +513,18 @@ def toggle_signal(signal_name: str) -> str:
 def toggle_class(condition: str, *args, base: str = "", **kwargs) -> DatastarAttr:
     """Toggle Tailwind classes based on a condition.
 
-    Binary: toggle_class("$active", "bg-blue-500", "bg-gray-300", base="p-4")
-    Multi-state: toggle_class("$status", success="bg-green-500", error="bg-red-500", _="bg-gray-300", base="p-4")
+    Binary: toggle_class("active", "bg-blue-500", "bg-gray-300", base="p-4")
+    Multi-state: toggle_class("status", success="bg-green-500", error="bg-red-500", _="bg-gray-300", base="p-4")
     """
+    if not condition.startswith(("$", "!")):
+        condition = f"${condition}"
 
     def apply_base(classes: str) -> str:
-        """Prepend base classes if they exist."""
         if not base:
             return classes
         return f"{base} {classes}".strip() if classes else base
 
     if kwargs:
-        # Multi-state: Build chained ternary for string equality checks
         default = kwargs.pop("_", "")
         conditions = [
             f"{condition} === {_to_js_value(state)} ? {_to_js_value(apply_base(classes))}"
@@ -522,12 +533,11 @@ def toggle_class(condition: str, *args, base: str = "", **kwargs) -> DatastarAtt
         conditions.append(_to_js_value(apply_base(default)))
         expression = " : ".join(conditions)
     else:
-        # Binary: Simple ternary with positional args
         truthy = args[0] if args else ""
         falsy = args[1] if len(args) > 1 else ""
         expression = f"{condition} ? {_to_js_value(apply_base(truthy))} : {_to_js_value(apply_base(falsy))}"
 
-    return DatastarAttr({"data-attr-class-": expression})
+    return DatastarAttr({"data-attr-class": expression})
 
 
 def ds_ignore(*modifiers) -> DatastarAttr:

--- a/tests/integration/test_toggle_class_html.py
+++ b/tests/integration/test_toggle_class_html.py
@@ -11,7 +11,7 @@ def test_toggle_class_html_output():
     )
 
     html = str(button)
-    assert 'data-attr-class-=\'$active ? "bg-blue-500" : "bg-gray-300"\'' in html
+    assert 'data-attr-class=\'$active ? "bg-blue-500" : "bg-gray-300"\'' in html
     assert 'data-on-click="$active = !$active"' in html
 
 
@@ -31,7 +31,7 @@ def test_multi_state_html_output():
 
     html = str(status_div)
     # Check for the chained ternary structure
-    assert "data-attr-class-=" in html
+    assert "data-attr-class=" in html
     assert '$status === "loading"' in html
     assert '$status === "success"' in html
     assert '$status === "error"' in html
@@ -123,9 +123,9 @@ def test_no_unnecessary_attributes():
 
     html = str(simple)
 
-    # Should only have the data-attr-class- attribute
+    # Should only have the data-attr-class attribute
     assert html.count("data-") == 1
-    assert "data-attr-class-=" in html
+    assert "data-attr-class=" in html
 
     # Should not have any other Datastar attributes
     assert "data-class-" not in html

--- a/tests/unit/test_toggle_class.py
+++ b/tests/unit/test_toggle_class.py
@@ -11,51 +11,51 @@ class TestToggleClass:
         """Test basic toggle between two class sets."""
         result = toggle_class("$active", "bg-blue-500 text-white", "bg-gray-300 text-black")
 
-        assert "data-attr-class-" in result.attrs
+        assert "data-attr-class" in result.attrs
         expected = '$active ? "bg-blue-500 text-white" : "bg-gray-300 text-black"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_with_base_classes(self):
         """Test toggle with base classes that always apply."""
         result = toggle_class("$expanded", "scale-105 shadow-lg", "scale-100", base="transition-all duration-200 p-4")
 
         expected = '$expanded ? "transition-all duration-200 p-4 scale-105 shadow-lg" : "transition-all duration-200 p-4 scale-100"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_complex_condition(self):
         """Test with complex condition expression."""
         result = toggle_class("$currentStep >= 2", "bg-green-500 text-white", "bg-gray-300 text-gray-600")
 
         expected = '$currentStep >= 2 ? "bg-green-500 text-white" : "bg-gray-300 text-gray-600"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_empty_truthy(self):
         """Test with empty truthy classes."""
         result = toggle_class("$hidden", "", "block", base="p-4")
 
         expected = '$hidden ? "p-4" : "p-4 block"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_empty_falsy(self):
         """Test with empty falsy classes."""
         result = toggle_class("$visible", "block", "", base="p-4")
 
         expected = '$visible ? "p-4 block" : "p-4"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_only_base_classes(self):
         """Test with only base classes, no conditional."""
         result = toggle_class("$any", "", "", base="always-present")
 
         expected = '$any ? "always-present" : "always-present"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_integration_with_element(self):
         """Test that toggle_class integrates properly with elements."""
         button = Button("Click me", **toggle_class("$active", "bg-blue-500 text-white", "bg-gray-300 text-black"))
 
         html = str(button)
-        assert "data-attr-class-=" in html
+        assert "data-attr-class=" in html
         assert "bg-blue-500 text-white" in html
         assert "bg-gray-300 text-black" in html
 
@@ -69,7 +69,7 @@ class TestToggleClass:
         )
 
         html = str(div)
-        expected_attr = 'data-attr-class-=\'$isOpen ? "transition-all duration-300 max-h-96 overflow-visible" : "transition-all duration-300 max-h-0 overflow-hidden"\''
+        expected_attr = 'data-attr-class=\'$isOpen ? "transition-all duration-300 max-h-96 overflow-visible" : "transition-all duration-300 max-h-0 overflow-hidden"\''
         assert expected_attr in html
 
     def test_with_tailwind_modifiers(self):
@@ -78,26 +78,31 @@ class TestToggleClass:
             "$darkMode", "dark:bg-gray-900 dark:text-white hover:bg-gray-800", "bg-white text-gray-900 hover:bg-gray-50"
         )
 
-        assert "dark:bg-gray-900" in result.attrs["data-attr-class-"]
-        assert "hover:bg-gray-50" in result.attrs["data-attr-class-"]
+        assert "dark:bg-gray-900" in result.attrs["data-attr-class"]
+        assert "hover:bg-gray-50" in result.attrs["data-attr-class"]
 
     def test_comparison_with_ds_attr(self):
-        """Test that toggle_class produces same result as ds_attr with if_()."""
+        """Test that toggle_class produces similar result as ds_attr with if_()."""
         # Using toggle_class
         toggle_result = toggle_class("$active", "bg-blue-500", "bg-gray-300")
 
         # Using ds_attr with if_
         attr_result = ds_attr(class_=if_("$active", "bg-blue-500", "bg-gray-300"))
 
-        # Should produce the same result
-        assert toggle_result.attrs["data-attr-class-"] == attr_result.attrs["data-attr-class-"]
+        # They create different attribute names due to HTML underscore conversion issue
+        # toggle_class uses data-attr-class (no trailing dash) to avoid HTML conversion issues
+        # ds_attr creates data-attr-class- (with trailing dash)
+        assert "data-attr-class" in toggle_result.attrs
+        assert "data-attr-class-" in attr_result.attrs
+        # But the expression values should be the same
+        assert toggle_result.attrs["data-attr-class"] == attr_result.attrs["data-attr-class-"]
 
     def test_multiple_conditions(self):
         """Test with equality and comparison conditions."""
         result = toggle_class("$status === 'success'", "border-green-500 bg-green-50", "border-gray-300 bg-white")
 
-        assert "$status === 'success'" in result.attrs["data-attr-class-"]
-        assert "border-green-500 bg-green-50" in result.attrs["data-attr-class-"]
+        assert "$status === 'success'" in result.attrs["data-attr-class"]
+        assert "border-green-500 bg-green-50" in result.attrs["data-attr-class"]
 
     def test_whitespace_handling(self):
         """Test that whitespace is preserved as provided."""
@@ -105,7 +110,7 @@ class TestToggleClass:
 
         # Whitespace is preserved as given (with one space between base and additional)
         expected = '$active ? "p-4  rounded     bg-blue-500   text-white" : "p-4  rounded      bg-gray-300"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_real_world_step_component(self):
         """Test a real-world step component example."""
@@ -117,7 +122,7 @@ class TestToggleClass:
         )
 
         # Check it includes all the classes
-        attr_value = result.attrs["data-attr-class-"]
+        attr_value = result.attrs["data-attr-class"]
         assert "flex items-center gap-3 p-4 rounded-lg border-2 transition-colors" in attr_value
         assert "bg-blue-500 text-white border-blue-600 shadow-lg" in attr_value
         assert "bg-gray-300 text-gray-600 border-gray-300" in attr_value
@@ -131,7 +136,7 @@ class TestToggleClass:
             base="min-h-screen p-8 transition-colors duration-200",
         )
 
-        attr_value = result.attrs["data-attr-class-"]
+        attr_value = result.attrs["data-attr-class"]
         assert "min-h-screen p-8 transition-colors duration-200" in attr_value
         assert "$darkMode ?" in attr_value
 
@@ -145,7 +150,7 @@ class TestToggleClass:
             _="bg-gray-300",
         )
         expected = '$status === "success" ? "bg-green-500 text-white" : $status === "error" ? "bg-red-500 text-white" : $status === "warning" ? "bg-yellow-500 text-black" : "bg-gray-300"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_multi_state_with_base(self):
         """Test multi-state pattern with base classes always applied."""
@@ -157,7 +162,7 @@ class TestToggleClass:
             base="px-3 py-1 rounded",
         )
         expected = '$status === "success" ? "px-3 py-1 rounded bg-green-500 text-white" : $status === "error" ? "px-3 py-1 rounded bg-red-500 text-white" : "px-3 py-1 rounded bg-gray-300"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_multi_state_no_default(self):
         """Test multi-state pattern without default (_) case."""
@@ -168,13 +173,13 @@ class TestToggleClass:
             base="transition-colors duration-200",
         )
         expected = '$theme === "dark" ? "transition-colors duration-200 bg-gray-900 text-white" : $theme === "light" ? "transition-colors duration-200 bg-white text-gray-900" : "transition-colors duration-200"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_multi_state_single_option(self):
         """Test multi-state with just one named state and default."""
         result = toggle_class("$isSpecial", special="bg-gold-500 animate-pulse", _="bg-gray-100")
         expected = '$isSpecial === "special" ? "bg-gold-500 animate-pulse" : "bg-gray-100"'
-        assert result.attrs["data-attr-class-"] == expected
+        assert result.attrs["data-attr-class"] == expected
 
     def test_api_patterns(self):
         """Test that both API patterns work correctly."""
@@ -190,37 +195,39 @@ class TestToggleClass:
         multi_result = toggle_class("$status", success="bg-green-500", error="bg-red-500", _="bg-gray-300", base="p-4")
 
         # Binary should generate simple ternary
-        assert binary_result.attrs["data-attr-class-"] == '$active ? "p-4 bg-blue-500" : "p-4 bg-gray-300"'
+        assert binary_result.attrs["data-attr-class"] == '$active ? "p-4 bg-blue-500" : "p-4 bg-gray-300"'
 
         # Multi-state should generate chained ternaries
-        assert '$status === "success"' in multi_result.attrs["data-attr-class-"]
-        assert '$status === "error"' in multi_result.attrs["data-attr-class-"]
+        assert '$status === "success"' in multi_result.attrs["data-attr-class"]
+        assert '$status === "error"' in multi_result.attrs["data-attr-class"]
 
     def test_full_equivalence_simple(self):
-        """Test complete equivalence with ds_attr for simple cases."""
+        """Test that toggle_class generates equivalent expressions to ds_attr."""
         # Test 1: Simple binary
         toggle_result = toggle_class("$active", "on", "off")
         manual_result = ds_attr(class_=if_("$active", "on", "off"))
-        assert toggle_result.attrs == manual_result.attrs
+        # Compare expression values (different attribute names)
+        assert toggle_result.attrs["data-attr-class"] == manual_result.attrs["data-attr-class-"]
 
         # Test 2: With base classes
         toggle_result = toggle_class("$expanded", "h-auto", "h-0", base="overflow-hidden transition-height")
         manual_result = ds_attr(
             class_=if_("$expanded", "overflow-hidden transition-height h-auto", "overflow-hidden transition-height h-0")
         )
-        assert toggle_result.attrs == manual_result.attrs
+        assert toggle_result.attrs["data-attr-class"] == manual_result.attrs["data-attr-class-"]
 
         # Test 3: Complex condition
         toggle_result = toggle_class("$count > 10 && $enabled", "text-green-500", "text-gray-400")
         manual_result = ds_attr(class_=if_("$count > 10 && $enabled", "text-green-500", "text-gray-400"))
-        assert toggle_result.attrs == manual_result.attrs
+        assert toggle_result.attrs["data-attr-class"] == manual_result.attrs["data-attr-class-"]
 
     def test_full_equivalence_multi_state(self):
-        """Test complete equivalence with ds_attr for multi-state cases."""
+        """Test that toggle_class generates equivalent expressions for multi-state cases."""
         # Multi-state without base
         toggle_result = toggle_class("$theme", dark="bg-gray-900", light="bg-white", _="bg-gray-100")
         manual_result = ds_attr(class_=if_("$theme", dark="bg-gray-900", light="bg-white", _="bg-gray-100"))
-        assert toggle_result.attrs == manual_result.attrs
+        # Compare expression values (different attribute names)
+        assert toggle_result.attrs["data-attr-class"] == manual_result.attrs["data-attr-class-"]
 
         # Multi-state with base - manual version is more complex
         toggle_result = toggle_class(
@@ -228,4 +235,4 @@ class TestToggleClass:
         )
         # Manual equivalent would need to repeat base in each branch
         manual_expression = '$status === "success" ? "font-semibold text-green-500" : $status === "error" ? "font-semibold text-red-500" : "font-semibold text-gray-500"'
-        assert toggle_result.attrs["data-attr-class-"] == manual_expression
+        assert toggle_result.attrs["data-attr-class"] == manual_expression

--- a/uv.lock
+++ b/uv.lock
@@ -1047,7 +1047,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.1.19"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Fixed `t()` function to handle dynamic variable names passed as strings (e.g., `t(signal)` now correctly returns `` `${my_switch}` ``)
- Fixed `toggle_class()` to use `data-attr-class` without trailing dash to avoid HTML underscore-to-dash conversion issues
- Both binary and multi-state modes continue to work correctly with the expression-based approach

## Test plan
- [x] All 848 existing tests pass
- [x] Unit tests verify correct attribute generation
- [x] Integration tests verify correct HTML output
- [x] Code formatted with ruff
- [x] No linting issues