### PR TITLE
feat: add dynamic version display and improve demo CTAs

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -1047,7 +1047,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.1.26"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },

--- a/web/app.py
+++ b/web/app.py
@@ -2,11 +2,15 @@
 """StarHTML API Documentation - Interactive Documentation (Home Route)"""
 
 import os
+import tomllib
 from pathlib import Path
 
 from sections import sections as s
 from starhtml import *
 from starhtml.handlers import position_handler, split_handler
+
+with open(Path(__file__).parent.parent / "pyproject.toml", "rb") as f:
+    VERSION = tomllib.load(f)["project"]["version"]
 
 app, rt = star_app(
     title="StarHTML API Documentation",
@@ -172,7 +176,29 @@ def generate_interactive_docs_sections():
         # s.reactivity_section(),
         # s.expressions_logic_section(),
         # s.styling_section(),
+        demos_cta_section(),
     ]
+
+
+def demos_cta_section():
+    return Div(
+        Div(
+            H2(
+                "See It In Action",
+                Icon("vaadin:asterisk", cls="ml-2 text-4xl md:text-5xl lg:text-6xl rainbow-sync"),
+                cls="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black text-black mb-4 flex items-baseline",
+            ),
+            P("Explore interactive examples.", cls="text-lg md:text-xl text-gray-600 mb-8 sm:mb-12"),
+            A(
+                Icon("vaadin:asterisk", width="20", height="20", cls="mr-2 text-white"),
+                "Browse Live Demos",
+                href="/demos",
+                cls="inline-flex items-center px-6 py-3 text-base font-semibold text-white rounded-lg rainbow-sync-bg hover:scale-105 transition-transform",
+            ),
+            cls="w-full px-6 sm:px-8 lg:px-12",
+        ),
+        cls="pt-12 sm:pt-16 lg:pt-20 pb-24 sm:pb-32 lg:pb-40 bg-white border-t border-gray-200",
+    )
 
 
 def raw_api_markdown_content():
@@ -196,7 +222,7 @@ def raw_api_markdown_content():
 def nav_left_section():
     return Div(
         Span("starHTML", cls="text-lg font-bold text-black"),
-        Span("v0.1.26", cls="text-xs font-mono text-gray-400 ml-2"),
+        Span(f"v{VERSION}", cls="text-xs font-mono text-gray-400 ml-2"),
         cls="flex items-baseline",
     )
 

--- a/web/demos.py
+++ b/web/demos.py
@@ -885,27 +885,19 @@ def home():
             ),
             Div(
                 Div(
-                    H2("Production", cls="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black text-white mb-4"),
-                    P("Ship real applications with confidence.", cls="text-lg md:text-xl text-white/90 mb-8 sm:mb-12"),
-                    Div(
-                        *[demo_card(demo) for demo in demos_by_level("Production")],
-                        cls="grid grid-cols-1 sm:grid-cols-2 gap-6",
+                    H2("Ready to Build?", cls="text-5xl sm:text-6xl md:text-7xl lg:text-8xl font-black text-white mb-4"),
+                    P("Your first star awaits.", cls="text-lg md:text-xl text-white/80 mb-8 sm:mb-12"),
+                    A(
+                        Icon("tabler:star-filled", width="20", height="20", cls="mr-2"),
+                        "Add your star to our galaxy",
+                        href="https://github.com/banditburai/starHTML",
+                        target="_blank",
+                        cls="inline-flex items-center px-6 py-3 text-base font-semibold text-black bg-white rounded-lg hover:bg-gray-100 transition-colors",
                     ),
                     cls="w-full px-6 sm:px-8 lg:px-12",
                 ),
-                cls="py-12 sm:py-16 lg:py-20 bg-gradient-to-br from-gray-900 via-black to-gray-800",
+                cls="pt-12 sm:pt-16 lg:pt-20 pb-24 sm:pb-32 lg:pb-40 bg-gradient-to-b from-gray-100 via-blue-950 to-black",
             ),
-        ),
-        Footer(
-            Div(
-                Div(
-                    P("StarHTML Demo Hub", cls="text-sm font-semibold text-gray-600 mb-2"),
-                    P("© 2025 - Interactive Python Components", cls="text-xs text-gray-400"),
-                    cls="text-center",
-                ),
-                cls="w-full px-6 sm:px-8 lg:px-12 py-8",
-            ),
-            cls="bg-white border-t border-gray-100 mt-12",
         ),
         cls="min-h-screen bg-white",
         data_on_click="""

--- a/web/uv.lock
+++ b/web/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [[package]]
@@ -478,7 +478,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.1.26"
+version = "0.2.0"
 source = { directory = "../" }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Add dynamic version reading from pyproject.toml in app.py navigation
- Add CTA section to docs homepage with rainbow asterisk branding  
- Replace empty Production section with star/galaxy themed CTA in demos
- Update lockfiles with uv 0.8.22 for deployment compatibility

## Changes
- `web/app.py`: Dynamic version display + new "See It In Action" CTA section
- `web/demos.py`: Replace Production section with "Ready to Build?" CTA
- `uv.lock` & `web/uv.lock`: Updated for uv 0.8.22 compatibility