### PR TITLE
fix: unwrap dict object literals for data-* attributes

### DIFF
--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -418,7 +418,7 @@ _JS_EXPR_PREFIXES = ("$", "`", "!", "(", "'", "evt.")
 _JS_EXPR_KEYWORDS = {"true", "false", "null", "undefined"}
 
 
-def _to_js(value: Any, allow_expressions: bool = True) -> str:
+def _to_js(value: Any, allow_expressions: bool = True, wrap_objects: bool = True) -> str:
     match value:
         case Expr() as expr:
             return expr.to_js()
@@ -437,7 +437,7 @@ def _to_js(value: Any, allow_expressions: bool = True) -> str:
                 return json.dumps(d)
             except (TypeError, ValueError):
                 items = [f"{_to_js(k, allow_expressions)}: {_to_js(v, allow_expressions)}" for k, v in d.items()]
-                return f"({{{', '.join(items)}}})"
+                return f"({{{', '.join(items)}}})" if wrap_objects else f"{{{', '.join(items)}}}"
         case list() | tuple() as l:
             try:
                 return json.dumps(l)
@@ -716,6 +716,11 @@ def process_datastar_kwargs(kwargs: dict) -> tuple[dict, set[Signal]]:
                     js_str = str(expr)
                 final_key = f"{normalized_key}{_build_modifier_suffix(modifiers)}"
                 processed[final_key] = NotStr(js_str)
+            case dict() as d:
+                for v in d.values():
+                    if isinstance(v, Expr | Signal):
+                        collect(v)
+                processed[normalized_key] = NotStr(_to_js(d, wrap_objects=not key.startswith("data_")))
             case Expr() as expr:
                 collect(expr)
                 js_str = expr.to_js()
@@ -725,7 +730,7 @@ def process_datastar_kwargs(kwargs: dict) -> tuple[dict, set[Signal]]:
                     processed["data-class"] = NotStr(js_str)
                 else:
                     processed[normalized_key] = NotStr(js_str)
-            case _JSLiteral() | _JSRaw() | dict() as val:
+            case _JSLiteral() | _JSRaw() as val:
                 processed[normalized_key] = NotStr(_to_js(val))
             case _:
                 if key.startswith(("data_style_", "data_class_", "data_attr_")):

--- a/tests/unit/test_datastar_kwargs_processing.py
+++ b/tests/unit/test_datastar_kwargs_processing.py
@@ -470,3 +470,101 @@ class TestConsistency:
         processed, _ = process_datastar_kwargs(kwargs)
 
         assert isinstance(processed["data-show"], NotStr)
+
+
+class TestDictWrappingFix:
+    """Test that dicts in data_* attributes are NOT wrapped in parens."""
+
+    def test_data_class_dict_no_parens(self):
+        """data_class dict should produce object literal WITHOUT parens."""
+        active = Signal("active", False)
+        kwargs = {"data_class": {"text-muted": ~active}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["data-class"])
+        assert not value.startswith("(")
+        assert not value.endswith(")")
+        assert "text-muted" in value
+        assert active in signals
+
+    def test_data_style_dict_no_parens(self):
+        """data_style dict should produce object literal WITHOUT parens."""
+        width = Signal("width", 100)
+        kwargs = {"data_style": {"width": width + "px"}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["data-style"])
+        assert not value.startswith("(")
+        assert not value.endswith(")")
+        assert width in signals
+
+    def test_data_attr_dict_no_parens(self):
+        """data_attr dict should produce object literal WITHOUT parens."""
+        disabled = Signal("disabled", False)
+        kwargs = {"data_attr": {"disabled": disabled}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["data-attr"])
+        assert not value.startswith("(")
+        assert not value.endswith(")")
+        assert disabled in signals
+
+    def test_non_data_dict_has_parens(self):
+        """Non-data-* dicts should STILL have parens for backward compatibility."""
+        sig = Signal("test", "value")
+        kwargs = {"custom_attr": {"key": sig}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["custom-attr"])
+        assert value.startswith("(")
+        assert value.endswith(")")
+        assert sig in signals
+
+    def test_data_class_dict_with_hyphenated_keys(self):
+        """data_class dict handles hyphenated class names correctly."""
+        selected = Signal("selected", True)
+        kwargs = {"data_class": {"text-muted-foreground": ~selected, "bg-primary": selected}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["data-class"])
+        assert "text-muted-foreground" in value
+        assert "bg-primary" in value
+        assert not value.startswith("(")
+        assert selected in signals
+
+    def test_data_style_dict_with_multiple_properties(self):
+        """data_style dict with multiple CSS properties."""
+        width = Signal("width", 100)
+        height = Signal("height", 50)
+        kwargs = {"data_style": {"width": width + "px", "height": height + "px"}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["data-style"])
+        assert "width" in value
+        assert "height" in value
+        assert not value.startswith("(")
+        assert width in signals
+        assert height in signals
+
+    def test_data_attr_dict_with_mixed_values(self):
+        """data_attr dict with signals and static values."""
+        disabled = Signal("disabled", False)
+        kwargs = {"data_attr": {"disabled": disabled, "aria-label": "Click me"}}
+        processed, signals = process_datastar_kwargs(kwargs)
+
+        value = str(processed["data-attr"])
+        assert "disabled" in value
+        assert "aria-label" in value
+        assert not value.startswith("(")
+        assert disabled in signals
+
+    def test_dict_signals_are_collected(self):
+        """Signals nested in dicts should be collected."""
+        active = Signal("active", True)
+        disabled = Signal("disabled", False)
+        kwargs = {"data_class": {"active": active, "disabled": ~disabled}}
+        _, signals = process_datastar_kwargs(kwargs)
+
+        assert active in signals
+        assert disabled in signals
+        assert len(signals) == 2

--- a/uv.lock
+++ b/uv.lock
@@ -1073,7 +1073,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.2.2"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Fix dict handling in `data_*` attributes by removing unnecessary parentheses wrapping.

**Before:** `data-class='({"active": $signal})'` ❌  
**After:** `data-class='{"active": $signal}'` ✅

## Changes

- Add `wrap_objects` parameter to `_to_js()` for conditional wrapping
- Handle dict case separately in `process_datastar_kwargs()` to collect signals
- Use `wrap_objects=False` for `data_*` attributes
- Maintain backward compatibility for non-`data_*` attributes

## Implementation

Modular approach with minimal code changes (~8 lines):
1. Updated `_to_js()` signature with `wrap_objects: bool = True`
2. Modified dict case to conditionally wrap: `if wrap_objects else`
3. Split dict handling in `process_datastar_kwargs()` to collect signals properly

## Testing

- ✅ All 935 tests pass
- ✅ Added 8 comprehensive tests in `TestDictWrappingFix`
- ✅ Tests cover `data_class`, `data_style`, `data_attr` with dicts
- ✅ Tests verify backward compatibility for non-`data_*` dicts
- ✅ Ruff linting and formatting passed

## Use Cases

```python
# Dict syntax now works correctly for hyphenated classes
data_class={"text-muted-foreground": ~selected, "bg-primary": is_active}

# Multiple CSS properties
data_style={"width": width + "px", "height": height + "px"}

# Mixed signals and static values
data_attr={"disabled": disabled, "aria-label": "Click me"}
```