### PR TITLE
fix: correctly handle _ref_only signals in data-signals attribute

### DIFF
--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -679,8 +679,9 @@ def _handle_data_signals(value: Any) -> Any:
         case dict() as d:
             signal_dict = d
         case Signal() as s:
-            signal_dict = s.to_dict()
-    return build_data_signals(signal_dict) if signal_dict else value
+            if not s._ref_only:
+                signal_dict = s.to_dict()
+    return build_data_signals(signal_dict) if signal_dict else None
 
 
 def _apply_additive_class_behavior(processed: dict) -> None:
@@ -702,7 +703,9 @@ def process_datastar_kwargs(kwargs: dict) -> tuple[dict, set[Signal]]:
 
     for key, value in kwargs.items():
         if key == "data_signals":
-            processed["data-signals"] = _handle_data_signals(value)
+            result = _handle_data_signals(value)
+            if result is not None:
+                processed["data-signals"] = result
             continue
 
         normalized_key = _normalize_data_key(key)

--- a/tests/unit/test_ref_only_signals.py
+++ b/tests/unit/test_ref_only_signals.py
@@ -1,0 +1,78 @@
+"""Test _ref_only Signal behavior."""
+
+import unittest
+
+from starhtml import Div, P, Span
+from starhtml.datastar import Signal
+
+
+class TestRefOnlySignals(unittest.TestCase):
+    """Test the _ref_only flag for signals that should not appear in data-signals."""
+
+    def test_regular_signal(self):
+        """Test regular signal is included in data-signals."""
+        div = Div(
+            (test1 := Signal("test1", "initial value")),
+            P("Signal value: ", Span(data_text="$test1")),
+        )
+        html = str(div)
+        self.assertIn("data-signals", html)
+        self.assertIn('test1: "initial value"', html)
+
+    def test_ref_only_signal_with_initial_value(self):
+        """Test _ref_only signal with initial value should not appear in data-signals."""
+        div = Div(
+            (test2 := Signal("test2", "ref only value", _ref_only=True)),
+            P("Signal value: ", Span(data_text="$test2")),
+        )
+        html = str(div)
+        self.assertNotIn("data-signals", html)
+
+    def test_ref_only_signal_no_initial_value(self):
+        """Test _ref_only signal without initial value should not appear in data-signals."""
+        div = Div(
+            (test3 := Signal("test3", None, _ref_only=True)),
+            P("Signal value: ", Span(data_text="$test3")),
+        )
+        html = str(div)
+        self.assertNotIn("data-signals", html)
+
+    def test_multiple_signals_mixed(self):
+        """Test mixed regular and _ref_only signals."""
+        div = Div(
+            (included := Signal("included", "value")),
+            (excluded := Signal("excluded", "value", _ref_only=True)),
+            P("Content"),
+        )
+        html = str(div)
+        self.assertIn("data-signals", html)
+        self.assertIn('included: "value"', html)
+        self.assertNotIn("excluded:", html)
+
+    def test_ref_only_in_data_signals_kwarg(self):
+        """Test _ref_only signals passed via data_signals kwarg are excluded."""
+        div = Div(
+            P("Content"),
+            data_signals=[
+                Signal("normal", "value"),
+                Signal("ref_only", "excluded", _ref_only=True),
+            ],
+        )
+        html = str(div)
+        self.assertIn("data-signals", html)
+        self.assertIn('normal: "value"', html)
+        self.assertNotIn("ref_only", html)
+
+    def test_all_ref_only_signals(self):
+        """Test when all signals are _ref_only, no data-signals attribute should be added."""
+        div = Div(
+            (ref1 := Signal("ref1", None, _ref_only=True)),
+            (ref2 := Signal("ref2", "value", _ref_only=True)),
+            P("Content"),
+        )
+        html = str(div)
+        self.assertNotIn("data-signals", html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -1073,7 +1073,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
Fixes a bug where `_ref_only` signals were incorrectly added to the `data-signals` attribute as malformed strings when they were the only signals in a container.

## The Problem
When a Div contained **only** `_ref_only` signals, they were being added to `data-signals` as malformed strings (e.g., `data-signals="$test2"`) instead of being omitted entirely.

**Before:**
```html
<div data-signals="$test2">...</div>
```

**After:**
```html
<div>...</div>
```

## Root Cause
The `_handle_data_signals` function was:
1. Not checking `_ref_only` for single Signal case
2. Returning the original value (list of Signal objects) instead of `None` when all signals were filtered out
3. This caused Signal objects to be stringified incorrectly

## Changes
- Added `_ref_only` check for single Signal case in `_handle_data_signals`
- Changed return value from `value` to `None` when `signal_dict` is empty
- Updated `process_datastar_kwargs` to skip setting attribute when result is `None`
- Added comprehensive test coverage in `tests/unit/test_ref_only_signals.py`

## Testing
- ✅ All 6 new tests pass
- ✅ All 935 existing tests continue to pass
- ✅ Ruff linting and formatting passes
- ✅ Pyright type checking passes

## Behavior Tests
The new tests verify:
- Regular signals still work correctly
- `_ref_only` signals with/without initial values are omitted
- Mixed regular and `_ref_only` signals work correctly
- `_ref_only` signals via `data_signals` kwarg are filtered
- All `_ref_only` signals result in no `data-signals` attribute