### PR TITLE
feat: Starlette 1.0, action payload fix, relay shutdown

### DIFF
--- a/API.md
+++ b/API.md
@@ -468,7 +468,7 @@ data_effect=[
 data_effect=is_form_complete.then(auto_save_data)
 
 # API calls on signal changes
-data_effect=search_query.length >= 3 & post("/api/search", q=search_query)
+data_effect=search_query.length >= 3 & post("/api/search")
 ```
 
 **Key Differences:**
@@ -477,21 +477,92 @@ data_effect=search_query.length >= 3 & post("/api/search", q=search_query)
 
 ### HTTP Actions
 
+Use `get()`, `post()`, `put()`, `patch()`, and `delete()` to make requests from the browser.
+
+**Important:** Datastar automatically sends **all signals** as the request body. You don't pass user data as keyword arguments — your server-side route handler receives every signal value by default.
+
 ```python
-# Simple requests
+# All signal values are sent automatically — no need to specify data
 data_on_click=get("/api/data")
 data_on_click=post("/api/submit")
-data_on_click=delete(f"/api/items/{item_id}")
-
-# With parameters
-data_on_click=get("/api/search", q=search_term)
-data_on_click=post("/api/contact", name=name, email=email)
+data_on_click=delete(f"/api/items/{item_id}")  # item_id is a Python variable baked into the URL at render time
 
 # Conditional requests
-data_on_click=is_valid.then(post("/api/submit", data=form_data))
+data_on_click=is_valid.then(post("/api/submit"))
+```
+
+**Sending specific data instead of all signals:**
+
+Use the `payload` option to send only certain values. Use `js()` to reference browser-side values (like DOM events or element properties) that don't exist in Python:
+
+```python
+# Send only "text" — derived from a browser-side DOM value
+data_on_blur=post("/api/edit", payload={"text": js("evt.target.innerText.trim()")})
+```
+
+**Action options:**
+
+All keyword arguments are [Datastar action options](https://data-star.dev/reference/action_plugins/backend), not user data. Available options include `contentType`, `headers`, `payload`, `selector`, `filterSignals`, and others.
+
+```python
+# Set content type for form submissions
+data_on_click=post("/api/submit", contentType="form")
+
+# Send only signals whose names match a regex
+data_on_click=post("/api/submit", filterSignals="name|email")
 ```
 
 ## Advanced Features
+
+### Startup & Shutdown
+
+Run code when your app starts (connect to a database, warm a cache) or stops (close connections, flush logs). There are four ways to register these handlers — pick whichever fits your situation.
+
+**Constructor lists** — simplest for quick setup:
+
+```python
+app, rt = star_app(
+    on_startup=[init_db, warm_cache],
+    on_shutdown=[close_db],
+)
+```
+
+**Lifespan context manager** — best when startup and shutdown are paired (e.g. open/close the same resource):
+
+```python
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app):
+    db = await connect_db()
+    yield
+    await db.close()
+
+app, rt = star_app(lifespan=lifespan)
+```
+
+**Decorator** — register handlers after creating the app:
+
+```python
+@app.on_event("startup")
+async def init_db():
+    ...
+
+@app.on_event("shutdown")
+def cleanup():
+    ...
+```
+
+**Programmatic** — useful when handlers come from plugins or configuration:
+
+```python
+app.add_lifecycle_handler("startup", init_db)
+app.add_lifecycle_handler("shutdown", close_db)
+```
+
+All handlers can be sync or async, and can optionally accept the `app` instance as a parameter.
+
+**Combining approaches**: You can use a lifespan context manager *and* individual handlers together. The handlers run inside the lifespan context, so they can access any resources it initializes (e.g. a database connection created in the lifespan is available to startup handlers).
 
 ### Slot Attributes System
 
@@ -811,170 +882,160 @@ data_on_input=(search, {"debounce": 300})             # Wait 300ms after typing
 ```python
 from starhtml import *
 
-def contact_form():
-    return Form(
-        H2("Contact Us"),
-        
-        # Name field with inline signal definition
-        Div(
-            Label("Name", for_="name"),
-        Input(
-                (name := Signal("name", "")),         # Define signal inline
-                type="text",
-                id="name",
-            data_bind=name,
-                data_on_input=(name_error := Signal("name_error", "")).set(
-                switch([
-                        (~name, "Name is required"),
-                        (name.length < 2, "Name too short")
-                    ], default="")
-                ),
-                cls="form-input",
-            data_class_error=name_error
-        ),
-            Span(data_text=name_error, data_show=name_error, cls="error-text")
-        ),
-        
-        # Email field with inline signal definition
-        Div(
-            Label("Email", for_="email"),
-        Input(
-                (email := Signal("email", "")),       # Define signal inline
-            type="email",
-                id="email", 
-            data_bind=email,
-                data_on_input=(email_error := Signal("email_error", "")).set(
-                    switch([
-                        (~email, "Email is required"),
-                        (~email.contains("@"), "Invalid email format")
-                    ], default="")
-                ),
-                cls="form-input",
-                data_class_error=email_error
+app, rt = star_app()
+
+@rt("/")
+def home():
+    # Create signals for each form field
+    name = Signal("name", "")
+    em = Signal("email", "")
+    message = Signal("message", "")
+
+    # .validate() attaches a validation rule and returns attrs
+    # (data-bind, blur/input handlers, aria-invalid) to spread into the Input
+    name_v = name.validate(min_length, 2, "Name")
+    em_v = em.validate(email)
+
+    # form_submit() wires everything together:
+    #   - Runs all validations on submit, POSTs only if all pass
+    #   - Auto-creates contact_submitting / contact_submitted / contact_error signals
+    #   - reset_on_success clears listed signals after a successful submit
+    # Only validated signals need to be listed here — message has no rules.
+    fs = form_submit("/submit", name, em, name="contact", reset_on_success=True)
+
+    return Div(
+        name, em, message,   # Place signals to emit their data-signals attrs
+
+        Form(
+            fs,              # FormAttrs dict — sets action, method, data-on-submit, etc.
+
+            # Spread name_v into Input to get two-way binding + validation
+            Div(
+                Label("Name", fr="name"),
+                Input(name_v, type="text", id="name", name="name", cls="form-input"),
+                # name.err is the auto-created error signal (empty string = no error)
+                Span(data_text=name.err, data_show=name.err, cls="error-text"),
             ),
-            Span(data_text=email_error, data_show=email_error, cls="error-text")
+
+            # Email field — same pattern
+            Div(
+                Label("Email", fr="email"),
+                Input(em_v, type="email", id="email", name="email", cls="form-input"),
+                Span(data_text=em.err, data_show=em.err, cls="error-text"),
+            ),
+
+            # Message — no validation, just two-way binding via data_bind
+            Div(
+                Label("Message", fr="message"),
+                Textarea(data_bind=message, id="message", name="message", rows="4", cls="form-input"),
+            ),
+
+            # fs.submitting is a Signal — use it for loading state
+            Button(
+                data_text=fs.submitting.if_("Sending...", "Send Message"),
+                type="submit",
+                data_attr_disabled=fs.submitting,
+                cls="btn btn-primary",
+            ),
         ),
-        
-        # Message field
-        Div(
-            Label("Message", for_="message"),
-        Textarea(
-                (message := Signal("message", "")),   # Define signal inline
-                id="message",
-            data_bind=message,
-                rows="4",
-                cls="form-input"
-            )
-        ),
-        
-        # Submit button
-        Button(
-            (is_submitting := Signal("is_submitting", False)),  # Define inline
-            data_text=is_submitting.if_("Sending...", "Send Message"),
-            type="submit",
-            data_attr_disabled=is_submitting | name_error | email_error | ~all(name, email, message),
-            cls="btn btn-primary"
-        ),
-        
-        # Form submission
-        data_on_submit=([
-            is_submitting.set(True),
-            post("/api/contact", name=name, email=email, message=message)
-        ], {"prevent": True}),
-        
-        cls="contact-form"
+        cls="contact-form",
     )
+
+@rt("/submit", methods=["POST"])
+@sse
+async def submit_form(name: str = "", email: str = "", message: str = ""):
+    import asyncio
+    # Show loading state on the button
+    yield signals(contact_submitting=True)
+    await asyncio.sleep(0.5)  # Simulate work
+    # End loading and mark success — reset_on_success will clear the form
+    yield signals(contact_submitting=False, contact_submitted=True)
 ```
 
 ### Chat with Server-Sent Events (SSE)
 
 ```python
 from starhtml import *
+import time
 
 def chat_app():
+    message = Signal("message", "")
+    sending = Signal("sending", False)
+
     return Div(
+        message, sending,  # Signals render as hidden setup attributes
+        
         H1("Live Chat"),
         
         # Messages container
-        Div(
-            id="messages",
-            cls="messages-container"
-        ),
+        Div(id="messages", cls="messages-container"),
         
         # Chat input form
         Form(
             Input(
-                (message := Signal("message", "")),
-                (sending := Signal("sending", False)),
                 placeholder="Type your message...",
-                data_bind=message,
-                data_attr_disabled=sending,
+                data_bind=message,           # Two-way bind to message signal
+                data_attr_disabled=sending,   # Disable while sending
                 cls="message-input"
             ),
             
             Button(
                 data_text=sending.if_("Sending...", "Send"),
                 type="submit",
-                data_attr_disabled=sending | ~message,
+                data_attr_disabled=sending | ~message,  # Disabled when sending or empty
                 cls="send-button"
             ),
             
-            # Submit triggers SSE endpoint
-            data_on_submit=(post("/chat/send", text=message), {"prevent": True}),
+            # post() sends all current signal values to the server
+            data_on_submit=(post("/chat/send"), {"prevent": True}),
             cls="chat-form"
         ),
         
         cls="chat-app"
     )
 
-# SSE endpoint for sending messages
+# @sse makes the handler yield SSE events instead of returning a response
 @rt("/chat/send", methods=["POST"])
 @sse
-def send_message(message: str = ""):
-    import time
-    
-    # Show sending state
+def send_message(message: str = ""):  # Signal values arrive as parameters
+    # Update sending signal on the client
     yield signals(sending=True)
     
-    # Simulate message processing
-    time.sleep(0.5)
+    time.sleep(0.5)  # Simulated delay
     
-    # Add message to chat
-    message_element = Div(
-        Span("You", cls="username"),
-        Span(message, cls="message-text"),
-        Span(time.strftime("%H:%M"), cls="timestamp"),
-        cls="message user-message"
+    # Append user message to chat
+    yield elements(
+        Div(
+            Span("You", cls="username"),
+            Span(message, cls="message-text"),
+            Span(time.strftime("%H:%M"), cls="timestamp"),
+            cls="message user-message"
+        ),
+        "#messages", "append"
     )
     
-    # Append new message to chat
-    yield elements(message_element, "#messages", "append")
+    time.sleep(1)  # Simulated delay
     
-    # Simulate server response
-    time.sleep(1)
-    
-    # Add bot response
-    bot_response = Div(
-        Span("Bot", cls="username"),
-        Span(f"Echo: {message}", cls="message-text"),
-        Span(time.strftime("%H:%M"), cls="timestamp"),
-        cls="message bot-message"
+    # Append bot response
+    yield elements(
+        Div(
+            Span("Bot", cls="username"),
+            Span(f"Echo: {message}", cls="message-text"),
+            Span(time.strftime("%H:%M"), cls="timestamp"),
+            cls="message bot-message"
+        ),
+        "#messages", "append"
     )
     
-    yield elements(bot_response, "#messages", "append")
-    
-    # Clear form and reset state
-    yield signals(
-        message="",      # Clear input
-        sending=False    # Reset sending state
-    )
+    # Clear input and reset sending state
+    yield signals(message="", sending=False)
 
-# ⚠️ SSE Best Practice: When replacing elements (not appending), 
-# always preserve id attributes to allow future targeting:
-# 
+# ⚠️ SSE Best Practice: When replacing elements (not appending),
+# preserve the id so the selector keeps working for future updates:
+#
 # yield elements(
 #     Div("New content", id="messages", cls="messages-container"),
-#     "#messages"  # ← Same id preserved in replacement
+#     "#messages"  # Replacement still has id="messages"
 # )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     # Core (Pyodide/WASM compatible)
-    "starlette",
+    "starlette~=1.0",
     "httpx",
     "beautifulsoup4",
     "python-dateutil",
@@ -207,6 +207,7 @@ reportArgumentType = false
 dev = [
     "psutil>=7.0.0",
     "pytest-asyncio>=1.1.0",
+    "pytest-cov>=6.1.1",
     "python-multipart>=0.0.20",
 ]
 

--- a/src/starhtml/__init__.py
+++ b/src/starhtml/__init__.py
@@ -67,7 +67,6 @@ from starlette.responses import (
 from starlette.responses import JSONResponse as JSONResponseOrig
 from starlette.routing import Mount, Route, WebSocketRoute
 from starlette.staticfiles import StaticFiles
-from starlette.templating import Jinja2Templates
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 from starlette.websockets import WebSocket, WebSocketDisconnect, WebSocketState

--- a/src/starhtml/core.py
+++ b/src/starhtml/core.py
@@ -1,16 +1,15 @@
 """The `StarHTML` subclass of `Starlette`"""
 
-import asyncio
 import logging
 import os
 import re
 
 logger = logging.getLogger(__name__)
 from collections.abc import Callable
-from copy import deepcopy
+from contextlib import asynccontextmanager, nullcontext
 from functools import partialmethod
 from pathlib import Path as PathlibPath
-from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 from fastcore.utils import (
     Path,
@@ -29,7 +28,7 @@ from starlette.responses import FileResponse, RedirectResponse, Response
 from starlette.routing import Mount, Route, WebSocketRoute
 
 from .realtime import _ws_endp, set_devtools_context, setup_ws
-from .server import _mk_locfunc, _wrap_call, _wrap_ex, _wrap_req, all_meths, cookie, render_response, serve
+from .server import _handle, _mk_locfunc, _wrap_call, _wrap_ex, _wrap_req, all_meths, cookie, render_response, serve
 from .starapp import Beforeware, _datastar_cdn_url, def_hdrs
 from .utils import _list, _params, get_key, noop_body, reg_re_param
 
@@ -47,9 +46,12 @@ DEFAULT_PKG_PREFIX = "/_pkg"
 
 __all__ = [
     "StarHTML",
+    "StarRoute",
+    "Lifespan",
     "Request",
     "Response",
     "Route",
+    "Mount",
     "WebSocketRoute",
     "HTTPException",
     "RedirectResponse",
@@ -62,6 +64,69 @@ __all__ = [
     "register_package_static",
     "Registrable",
 ]
+
+
+async def _run_handler(handler, app):
+    await _handle(handler, [app] if _params(handler) else [])
+
+
+class Lifespan:
+    """Handlers run INSIDE the user lifespan so they can access resources it initializes."""
+
+    def __init__(self, startup=None, shutdown=None, lifespan=None):
+        self.startup = listify(startup)
+        self.shutdown = listify(shutdown)
+        self.lifespan = lifespan
+
+    @asynccontextmanager
+    async def __call__(self, app):
+        ctx = self.lifespan(app) if self.lifespan else nullcontext()
+        async with ctx:
+            for f in self.startup:
+                await _run_handler(f, app)
+            yield
+            for f in self.shutdown:
+                await _run_handler(f, app)
+
+
+class StarRoute(Route):
+    """Route subclass that wraps endpoints with StarHTML's request processing pipeline."""
+
+    def __init__(
+        self,
+        path,
+        endpoint,
+        *,
+        app=None,
+        methods=None,
+        name=None,
+        include_in_schema=True,
+        middleware=None,
+        body_wrap=None,
+    ):
+        self._original_endpoint = endpoint
+        self._body_wrap = body_wrap
+        self._bound = False
+        methods = methods or ["GET", "POST"]
+        super().__init__(
+            path, endpoint, methods=methods, name=name, include_in_schema=include_in_schema, middleware=middleware
+        )
+        if app:
+            self._bind(app)
+
+    def _bind(self, app):
+        if self._bound:
+            return
+        wrapped = app._endp(self._original_endpoint, self._body_wrap or app.body_wrap)
+        # Second super().__init__ is safe — it fully overwrites all Route attrs
+        super().__init__(
+            self.path,
+            wrapped,
+            methods=self.methods,
+            name=self.name,
+            include_in_schema=self.include_in_schema,
+        )
+        self._bound = True
 
 
 class StarHTML(Starlette):
@@ -111,8 +176,8 @@ class StarHTML(Starlette):
         htmlkw = htmlkw or {}
         if default_hdrs:
             hdrs = def_hdrs(datastar_url=self._datastar_url) + hdrs
-        on_startup, on_shutdown = listify(on_startup) or None, listify(on_shutdown) or None
-        self.lifespan, self.hdrs, self.ftrs = lifespan, hdrs, ftrs
+        self._lifespan = Lifespan(on_startup, on_shutdown, lifespan)
+        self.hdrs, self.ftrs = hdrs, ftrs
         self.body_wrap, self.before, self.after, self.htmlkw, self.bodykw = body_wrap, before, after, htmlkw, bodykw
         self._registered_plugins: list = []
         self._plugin_hdrs: tuple = ()
@@ -157,12 +222,12 @@ class StarHTML(Starlette):
             routes,
             middleware=middleware,
             exception_handlers=excs,
-            on_startup=on_startup,
-            on_shutdown=on_shutdown,
-            lifespan=lifespan,
+            lifespan=self._lifespan,
         )
 
-        # Single route serves all JS: datastar, plugins, devtools, and shared chunks.
+        self._bind_star_routes(self.router.routes)
+
+        # One route for all framework JS avoids chunk 404s when plugins share bundled dependencies
         self.register_package_static(
             name="starhtml",
             static_path=PathlibPath(__file__).parent / "static" / "js",
@@ -179,7 +244,16 @@ class StarHTML(Starlette):
         if static_path:
             self.static_route_exts(static_path=static_path)
 
-    def add_route(self, route) -> None:
+    def _bind_star_routes(self, routes):
+        for route in routes:
+            if isinstance(route, StarRoute):
+                route._bind(self)
+            elif isinstance(route, Mount) and route.routes:
+                self._bind_star_routes(route.routes)
+
+    def add_route(self, route):
+        if isinstance(route, StarRoute):
+            route._bind(self)
         route.methods = [m.upper() if isinstance(m, str) else m for m in listify(route.methods)]
         self.router.routes = [
             r
@@ -226,18 +300,51 @@ class StarHTML(Starlette):
             headers=dict(response.headers),
         )
 
+    def add_lifecycle_handler(self, event: Literal["startup", "shutdown"], handler: Callable) -> None:
+        """Register a startup or shutdown handler."""
+        getattr(self._lifespan, event).append(handler)
+
+    def on_event(self, event: Literal["startup", "shutdown"]) -> Callable:
+        """Decorator to register a startup or shutdown handler."""
+
+        def _decorator(func: Callable) -> Callable:
+            self.add_lifecycle_handler(event, func)
+            return func
+
+        return _decorator
+
+    def add_exception_handler(self, exc_class_or_status_code: int | type[Exception], handler: Callable) -> None:
+        wrapped = _wrap_ex(
+            handler,
+            exc_class_or_status_code,
+            self.hdrs,
+            self.ftrs,
+            self.htmlkw,
+            self.bodykw,
+            body_wrap=self.body_wrap,
+        )
+        super().add_exception_handler(exc_class_or_status_code, wrapped)
+
+    def exception_handler(self, exc_class_or_status_code: int | type[Exception]) -> Callable:
+        """Decorator to register an exception handler."""
+
+        def _decorator(func: Callable) -> Callable:
+            self.add_exception_handler(exc_class_or_status_code, func)
+            return func
+
+        return _decorator
+
 
 @patch
 def _endp(self: StarHTML, f, body_wrap):
-    """Create a Starlette-compatible endpoint from a StarHTML route function"""
     sig = signature_ex(f, True)
     _has_devtools = self._devtools
 
     async def _f(req):
         resp = None
         req.injects = []
-        req.hdrs, req.ftrs, req.htmlkw, req.bodykw = map(deepcopy, (self.hdrs, self.ftrs, self.htmlkw, self.bodykw))
-        req.hdrs, req.ftrs = listify(req.hdrs), listify(req.ftrs)
+        req.hdrs, req.ftrs = list(self.hdrs), list(self.ftrs)
+        req.htmlkw, req.bodykw = dict(self.htmlkw), dict(self.bodykw)
         # No reset needed — each ASGI request gets its own contextvars copy
         if _has_devtools:
             set_devtools_context(handler=f.__qualname__, route=req.url.path)
@@ -264,7 +371,6 @@ def _endp(self: StarHTML, f, body_wrap):
 
 @patch
 def _add_ws(self: StarHTML, func, path, conn, disconn, name, middleware):
-    """Add a WebSocket route to the application"""
     endp = _ws_endp(func, conn, disconn)
     route = WebSocketRoute(path, endpoint=endp, name=name, middleware=middleware)
     route.methods = ["ws"]
@@ -274,8 +380,6 @@ def _add_ws(self: StarHTML, func, path, conn, disconn, name, middleware):
 
 @patch
 def ws(self: StarHTML, path: str, conn=None, disconn=None, name=None, middleware=None):
-    """Add a websocket route at `path`"""
-
     def f(func=noop):
         return self._add_ws(func, path, conn, disconn, name=name, middleware=middleware)  # type: ignore[attr-defined]
 
@@ -289,7 +393,6 @@ def nested_name(f):
 
 @patch
 def _add_route(self: StarHTML, func, path, methods, name, include_in_schema, body_wrap):
-    """Add an HTTP route to the application"""
     n, fn, p = name, nested_name(func), None if callable(path) else path
     if methods:
         m = [methods] if isinstance(methods, str) else methods
@@ -301,12 +404,14 @@ def _add_route(self: StarHTML, func, path, methods, name, include_in_schema, bod
         n = fn
     if not p:
         p = "/" + ("" if fn == "index" else fn)
-    route = Route(
+    route = StarRoute(
         p,
-        endpoint=self._endp(func, body_wrap or self.body_wrap),
+        func,
+        app=self,
         methods=m,
         name=n,
         include_in_schema=include_in_schema,
+        body_wrap=body_wrap,
     )
     self.add_route(route)
     lf = _mk_locfunc(func, p)
@@ -323,15 +428,12 @@ def route(
     include_in_schema: bool = True,
     body_wrap: Callable[..., Any] | None = None,
 ) -> Callable[..., Any]:
-    """Add a route at `path`"""
-
     def f(func: Callable[..., Any]) -> Callable[..., Any]:
         return self._add_route(func, path, methods, name=name, include_in_schema=include_in_schema, body_wrap=body_wrap)  # type: ignore[attr-defined]
 
     return f(path) if callable(path) else f
 
 
-# Add HTTP method decorators (@app.get, @app.post, etc.) via @patch
 for o in all_meths:
     setattr(StarHTML, o, partialmethod(StarHTML.route, methods=o))
 
@@ -488,27 +590,13 @@ def register(self: StarHTML, *items, prefix: str | None = None):
     merged = {"imports": {"datastar": self._datastar_url, **self._import_map}}
     self.hdrs.insert(0, Script(json.dumps(merged), type="importmap"))
 
-    # Wire lifecycle handlers
     for item in items:
         if id(item) in self._lifecycle_wired:
             continue
         self._lifecycle_wired.add(id(item))
         for event in ("startup", "shutdown"):
-            method = getattr(item, f"on_{event}", None)
-            if method is None:
-                continue
-            if asyncio.iscoroutinefunction(method):
-
-                async def _async(app=self, m=method):
-                    await m(app)
-
-                self.add_event_handler(event, _async)
-            else:
-
-                def _sync(app=self, m=method):
-                    m(app)
-
-                self.add_event_handler(event, _sync)
+            if (method := getattr(item, f"on_{event}", None)) is not None:
+                self.add_lifecycle_handler(event, method)
 
     return items[0] if len(items) == 1 else (tuple(items) or None)
 

--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -435,7 +435,8 @@ class Signal(Expr):
         self._ref_only = _ref_only
         self._is_computed = isinstance(initial, Expr)
         self.type_ = type_ or self._infer_type(initial)
-        self._validate_name()
+        self._check_name()
+        self._constraint_attrs: dict[str, Any] = {}
         self._id = f"{namespace}_{name}" if namespace else name
         self._js = f"${self._id}"
 
@@ -452,7 +453,7 @@ class Signal(Expr):
             return dict
         return type(initial)
 
-    def _validate_name(self):
+    def _check_name(self):
         if not re.match(r"^[a-z][a-z0-9_]*$", self._name):
             raise ValueError(f"Signal name must be snake_case: '{self._name}'")
 
@@ -496,6 +497,7 @@ class Signal(Expr):
     def validate(self, rule, *args, event="input", **kwargs) -> dict:
         "Validate-on-blur, re-validate-on-input."
         validation = rule(self, *args, **kwargs) if callable(rule) and not isinstance(rule, Expr) else rule
+        html_attrs = dict(self._constraint_attrs)  # prior attrs + anything rule() just set
         self._validation_expr = validation
         err = self.err
         attrs = {
@@ -505,9 +507,9 @@ class Signal(Expr):
             "data_class_error": err,
             "data_attr_aria_invalid": err.if_(True, False),
         }
-        # Used by StarUI Field component
         processed, _ = process_datastar_kwargs(attrs)
-        self._validate_html = {k: v for k, v in processed.items() if not k.startswith("data-signals")}
+        self._constraint_attrs = {k: v for k, v in processed.items() if not k.startswith("data-signals")}
+        self._constraint_attrs.update(html_attrs)
         return attrs
 
     def __getattr__(self, key: str) -> PropertyAccess:
@@ -658,24 +660,24 @@ def any_(*signals) -> _JSRaw:
     return _JSRaw(" || ".join(f"!!{_ensure_expr(s).to_js()}" for s in signals))
 
 
-def post(url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    return _action("post", url, data, **kwargs)
+def post(url: str, **kwargs) -> _JSRaw:
+    return _action("post", url, **kwargs)
 
 
-def get(url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    return _action("get", url, data, **kwargs)
+def get(url: str, **kwargs) -> _JSRaw:
+    return _action("get", url, **kwargs)
 
 
-def put(url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    return _action("put", url, data, **kwargs)
+def put(url: str, **kwargs) -> _JSRaw:
+    return _action("put", url, **kwargs)
 
 
-def patch(url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    return _action("patch", url, data, **kwargs)
+def patch(url: str, **kwargs) -> _JSRaw:
+    return _action("patch", url, **kwargs)
 
 
-def delete(url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    return _action("delete", url, data, **kwargs)
+def delete(url: str, **kwargs) -> _JSRaw:
+    return _action("delete", url, **kwargs)
 
 
 def _timer_ref(timer: "Signal", window: bool = False) -> str:
@@ -763,38 +765,10 @@ def scroll_to(
     )
 
 
-_ACTION_OPTIONS = frozenset(
-    {
-        "selector",
-        "headers",
-        "contentType",
-        "filterSignals",
-        "openWhenHidden",
-        "payload",
-        "requestCancellation",
-        "retry",
-        "retryInterval",
-        "retryScaler",
-        "retryMaxInterval",
-        "retryMaxRetries",
-        "retryMaxWaitMs",
-        "retryMaxCount",
-        "abort",
-    }
-)
-
-
-def _action(verb: str, url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    # kwargs that aren't Datastar options become payload data
-    user_data = dict(data or {})
-    options: dict[str, Any] = {}
-    for k, v in kwargs.items():
-        (options if k in _ACTION_OPTIONS else user_data)[k] = v
-    if user_data:
-        options["payload"] = user_data
-    if not options:
+def _action(verb: str, url: str, **kwargs) -> _JSRaw:
+    if not kwargs:
         return _JSRaw(f"@{verb}('{url}')")
-    opts = ", ".join(f"{k}: {to_js_value(v)}" for k, v in options.items())
+    opts = ", ".join(f"{k}: {to_js_value(v)}" for k, v in kwargs.items())
     return _JSRaw(f"@{verb}('{url}', {{{opts}}})")
 
 

--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -763,12 +763,39 @@ def scroll_to(
     )
 
 
+_ACTION_OPTIONS = frozenset(
+    {
+        "selector",
+        "headers",
+        "contentType",
+        "filterSignals",
+        "openWhenHidden",
+        "payload",
+        "requestCancellation",
+        "retry",
+        "retryInterval",
+        "retryScaler",
+        "retryMaxInterval",
+        "retryMaxRetries",
+        "retryMaxWaitMs",
+        "retryMaxCount",
+        "abort",
+    }
+)
+
+
 def _action(verb: str, url: str, data: dict[str, Any] | None = None, **kwargs) -> _JSRaw:
-    payload = {**(data or {}), **kwargs}
-    if not payload:
+    # kwargs that aren't Datastar options become payload data
+    user_data = dict(data or {})
+    options: dict[str, Any] = {}
+    for k, v in kwargs.items():
+        (options if k in _ACTION_OPTIONS else user_data)[k] = v
+    if user_data:
+        options["payload"] = user_data
+    if not options:
         return _JSRaw(f"@{verb}('{url}')")
-    parts = [f"{k}: {to_js_value(v)}" for k, v in payload.items()]
-    return _JSRaw(f"@{verb}('{url}', {{{', '.join(parts)}}})")
+    opts = ", ".join(f"{k}: {to_js_value(v)}" for k, v in options.items())
+    return _JSRaw(f"@{verb}('{url}', {{{opts}}})")
 
 
 console = js("console")

--- a/src/starhtml/forms.py
+++ b/src/starhtml/forms.py
@@ -33,13 +33,19 @@ __all__ = [
 _EMAIL_RE = r"[^\s@]+@[^\s@]+\.[^\s@]+"
 
 
+def _require(signal: Signal) -> None:
+    signal._constraint_attrs.update({"required": True, "aria-required": "true"})
+
+
 def required(signal: Signal, label: str = "This field") -> Expr:
     "Error message when empty, empty string when valid."
+    _require(signal)
     return (~signal).if_(f"{label} is required")
 
 
 def email(signal: Signal, *, re: str = _EMAIL_RE) -> Expr:
     "Email validation: required + regex."
+    _require(signal)
     return switch(
         [
             (~signal, "Email is required"),
@@ -50,6 +56,8 @@ def email(signal: Signal, *, re: str = _EMAIL_RE) -> Expr:
 
 def min_length(signal: Signal, n: int, label: str = "This field") -> Expr:
     "Required + minimum length."
+    _require(signal)
+    signal._constraint_attrs["minlength"] = str(n)
     return switch(
         [
             (~signal, f"{label} is required"),
@@ -60,13 +68,16 @@ def min_length(signal: Signal, n: int, label: str = "This field") -> Expr:
 
 def max_length(signal: Signal, n: int) -> Expr:
     "Maximum length (does not check required)."
+    signal._constraint_attrs["maxlength"] = str(n)
     return (signal.length > n).if_(f"Must be at most {n} characters")
 
 
 def pattern(signal: Signal, pat: str, message: str, *, optional: bool = False) -> Expr:
     "Regex pattern validation. Set optional=True to skip when empty."
+    signal._constraint_attrs["pattern"] = pat
     if optional:
         return (signal & ~regex(pat).test(signal)).if_(message)
+    _require(signal)
     return switch(
         [
             (~signal, "This field is required"),
@@ -77,6 +88,7 @@ def pattern(signal: Signal, pat: str, message: str, *, optional: bool = False) -
 
 def matches(signal: Signal, other: Signal, message: str = "Fields must match", *, label: str = "This field") -> Expr:
     "Must match another field (e.g., password confirmation)."
+    _require(signal)
     return switch(
         [
             (~signal, f"{label} is required"),
@@ -87,6 +99,7 @@ def matches(signal: Signal, other: Signal, message: str = "Fields must match", *
 
 def checked(signal: Signal, message: str = "This field is required") -> Expr:
     "Checkbox must be checked."
+    _require(signal)
     return (~signal).if_(message)
 
 
@@ -129,6 +142,7 @@ def form_submit(
     submitted: Signal | None = None,
     error: Signal | list[Signal] | None = None,
     focus_first_error: bool = True,
+    reset_on_success: bool = False,
 ) -> FormAttrs:
     "Datastar attrs for form submission. Auto-creates submitting/submitted/error signals from name=."
     orig = (submitting, submitted, error)
@@ -143,7 +157,7 @@ def form_submit(
     validate_all = [err.set(val) for err, val in fields.items()]
     can_submit = ~any_(*fields.keys()) & ~submitting
     clears = [e.set("") for e in (error if isinstance(error, list) else [error] if error else [])]
-    submit_action = seq(*clears, post(endpoint))
+    submit_action = seq(*clears, post(endpoint, contentType="form"))
 
     actions = [*validate_all, can_submit.then(submit_action)]
     if focus_first_error:
@@ -155,6 +169,9 @@ def form_submit(
     ]
     if auto_created:
         attrs["data_signals"] = auto_created
+    if reset_on_success and submitted:
+        attrs["data_on_signal_patch"] = submitted & form_reset(*signals)
+        attrs["data-on-signal-patch-filter"] = f"{{include: /^{submitted._id}$/}}"
     return FormAttrs(attrs, submitting=submitting, submitted=submitted, error=error)
 
 
@@ -183,10 +200,9 @@ async def parse_form(req: Request) -> FormData | dict[str, Any]:
         return await req.json()
     if not ctype.startswith("multipart/form-data"):
         return await req.form()
-    try:
-        boundary = ctype.split("boundary=")[1].strip()
-    except IndexError as e:
-        raise HTTPException(400, "Invalid form-data: no boundary") from e
+    if "boundary=" not in ctype:
+        raise HTTPException(400, "Invalid form-data: no boundary")
+    boundary = ctype.split("boundary=")[1].strip()
     min_len = len(boundary) + 6
     clen = int(req.headers.get("Content-Length", "0"))
     if clen <= min_len:
@@ -235,7 +251,7 @@ def _formitem(form: FormData | dict[str, Any], k: str) -> Any:
     if isinstance(form, dict):
         return form.get(k)
     o = form.getlist(k)
-    return o[0] if len(o) == 1 else o if o else None
+    return o[0] if len(o) == 1 else o or None
 
 
 def _fill_item(item: Any, obj: dict[str, Any]) -> Any:
@@ -261,9 +277,9 @@ def _fill_item(item: Any, obj: dict[str, Any]) -> Any:
                     attr.pop("checked", "")
             else:
                 attr["value"] = val
-        if tag == "textarea":
+        elif tag == "textarea":
             cs = (val,)
-        if tag == "select":
+        elif tag == "select":
             if isinstance(val, list):
                 for opt in cs:
                     if opt.tag == "option" and opt.get("value") in val:

--- a/src/starhtml/realtime.py
+++ b/src/starhtml/realtime.py
@@ -624,9 +624,32 @@ class Relay:
             self._deliver_shutdown(q)
         logger.debug("Relay shut down (%d subscribers notified)", len(subscribers))
 
-    def install(self, app) -> None:
-        """Call shutdown on app shutdown."""
-        app.add_event_handler("shutdown", self.shutdown)
+    def install(self, app, *, server=None) -> None:
+        """Hook relay shutdown into app lifespan and optionally server signal handler.
+
+        GOTCHA: ASGI lifespan "shutdown" fires *after* the server waits for open
+        connections — deadlocking long-lived SSE streams.  Passing *server* wraps
+        ``handle_exit`` so the relay shuts down on the first signal, before the
+        server blocks.
+        """
+        if not hasattr(app, "add_lifecycle_handler"):
+            raise AttributeError("App must support add_lifecycle_handler()")
+        app.add_lifecycle_handler("shutdown", self.shutdown)
+        if server:
+            self._wrap_server_exit(server)
+
+    def _wrap_server_exit(self, server) -> None:
+        """Wrap server.handle_exit to shutdown SSE before graceful shutdown waits."""
+        if hasattr(server, "_starhtml_relay_wrapped"):
+            return
+        orig = server.handle_exit
+
+        def _handle_exit(sig, frame):
+            self.shutdown()
+            orig(sig, frame)
+
+        server.handle_exit = _handle_exit
+        server._starhtml_relay_wrapped = True
 
     async def stream(self, *, shutdown: asyncio.Event | None = None) -> AsyncIterator[Any]:
         """Yield SSE items until shutdown, cancellation, or disconnect."""

--- a/src/starhtml/server.py
+++ b/src/starhtml/server.py
@@ -7,7 +7,6 @@ import os
 import sys
 import types
 from collections.abc import Mapping
-from copy import deepcopy
 from datetime import datetime
 from functools import partialmethod, update_wrapper
 from http import cookies
@@ -685,7 +684,7 @@ def _wrap_ex(f, status_code, hdrs, ftrs, htmlkw, bodykw, body_wrap):
     "Wrap exception handler"
 
     async def _f(req, exc):
-        req.hdrs, req.ftrs, req.htmlkw, req.bodykw = map(deepcopy, (hdrs, ftrs, htmlkw, bodykw))
+        req.hdrs, req.ftrs, req.htmlkw, req.bodykw = list(hdrs), list(ftrs), dict(htmlkw), dict(bodykw)
         req.body_wrap = body_wrap
         res = await _handle(f, (req, exc))
         return render_response(req, res, status_code=status_code)

--- a/src/starhtml/starapp.py
+++ b/src/starhtml/starapp.py
@@ -133,7 +133,8 @@ def star_app(
         body_wrap=body_wrap,
         datastar=datastar,
     )
-    app.static_route_exts(static_path=static_path)
+    if static_path:
+        app.static_route_exts(static_path=static_path)
 
     if not db_file:
         return app, app.route

--- a/tests/integration/test_live_reload.py
+++ b/tests/integration/test_live_reload.py
@@ -437,14 +437,19 @@ class TestLiveReloadRealWorldScenarios:
 
     def test_live_reload_with_complex_app(self):
         """Test live reload with a more complex application structure."""
-        app = StarHTMLWithLiveReload(reload_attempts=5, reload_interval=1000)
+        from starlette.middleware import Middleware
+        from starlette.middleware.base import BaseHTTPMiddleware
 
-        # Add some middleware-like behavior
-        @app.middleware("http")
         async def add_process_time_header(request, call_next):
             response = await call_next(request)
             response.headers["X-Process-Time"] = "0.001"
             return response
+
+        app = StarHTMLWithLiveReload(
+            reload_attempts=5,
+            reload_interval=1000,
+            middleware=[Middleware(BaseHTTPMiddleware, dispatch=add_process_time_header)],
+        )
 
         @app.route("/")
         def home():

--- a/tests/integration/test_server_functionality.py
+++ b/tests/integration/test_server_functionality.py
@@ -462,14 +462,15 @@ class TestRealServerBehavior:
 
     def test_middleware_integration(self):
         """Test that server works with middleware."""
-        app, rt = star_app()
+        from starlette.middleware import Middleware
+        from starlette.middleware.base import BaseHTTPMiddleware
 
-        # Add custom middleware
-        @app.middleware("http")
         async def add_custom_header(request, call_next):
             response = await call_next(request)
             response.headers["X-Custom-Middleware"] = "active"
             return response
+
+        app, rt = star_app(middleware=[Middleware(BaseHTTPMiddleware, dispatch=add_custom_header)])
 
         @rt("/middleware-test")
         def middleware_test():

--- a/tests/integration/test_starlette_compatibility.py
+++ b/tests/integration/test_starlette_compatibility.py
@@ -1,0 +1,59 @@
+from contextlib import asynccontextmanager
+
+from starhtml import StarHTML, TestClient
+
+
+def test_constructor_lifecycle_hooks_run():
+    events = []
+
+    def on_startup():
+        events.append("startup")
+
+    def on_shutdown():
+        events.append("shutdown")
+
+    app = StarHTML(on_startup=[on_startup], on_shutdown=[on_shutdown])
+
+    with TestClient(app):
+        assert events == ["startup"]
+
+    assert events == ["startup", "shutdown"]
+
+
+def test_on_event_decorator():
+    events = []
+    app = StarHTML()
+
+    @app.on_event("startup")
+    def on_startup():
+        events.append("startup")
+
+    @app.on_event("shutdown")
+    def on_shutdown():
+        events.append("shutdown")
+
+    with TestClient(app):
+        assert events == ["startup"]
+
+    assert events == ["startup", "shutdown"]
+
+
+def test_lifespan_wraps_hooks_in_defined_order():
+    events = []
+
+    @asynccontextmanager
+    async def lifespan(app):
+        events.append("lifespan_enter")
+        yield
+        events.append("lifespan_exit")
+
+    app = StarHTML(lifespan=lifespan, on_startup=[lambda: events.append("startup")])
+
+    @app.on_event("shutdown")
+    def on_shutdown():
+        events.append("shutdown")
+
+    with TestClient(app):
+        assert events == ["lifespan_enter", "startup"]
+
+    assert events == ["lifespan_enter", "startup", "shutdown", "lifespan_exit"]

--- a/tests/unit/test_core_coverage.py
+++ b/tests/unit/test_core_coverage.py
@@ -1,0 +1,415 @@
+"""Tests to cover uncovered lines in starhtml/core.py.
+
+Targets: datastar URL modes, after middleware, _add_route method-name inference,
+register_package_static file serving, mount method, register_package,
+_register_item dependencies, duplicate plugin skip, static_route, devtools_json.
+"""
+
+import tempfile
+from pathlib import Path
+
+from starlette.responses import PlainTextResponse
+from starlette.testclient import TestClient
+
+from starhtml import StarHTML
+from starhtml.core import _register_item
+
+# ---------------------------------------------------------------------------
+# datastar URL configuration (lines 170, 174)
+# ---------------------------------------------------------------------------
+
+
+class TestDatastarURLConfig:
+    def test_datastar_cdn_mode(self):
+        """datastar='cdn' uses the CDN URL."""
+        app = StarHTML(datastar="cdn")
+        assert "cdn" in app._datastar_url.lower() or "datastar" in app._datastar_url
+
+    def test_datastar_custom_url(self):
+        """datastar=<custom string> uses that string as the URL."""
+        app = StarHTML(datastar="https://example.com/my-datastar.js")
+        assert app._datastar_url == "https://example.com/my-datastar.js"
+
+
+# ---------------------------------------------------------------------------
+# after middleware in _endp (lines 363-366)
+# ---------------------------------------------------------------------------
+
+
+class TestAfterMiddleware:
+    def test_after_handler_receives_response(self):
+        """After handlers receive the response and can inspect it."""
+        seen_responses = []
+
+        def after_handler(resp):
+            seen_responses.append(resp)
+
+        app = StarHTML(after=[after_handler])
+
+        @app.route("/test")
+        def handler():
+            return "hello"
+
+        client = TestClient(app)
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert len(seen_responses) == 1
+
+    def test_after_handler_can_replace_response(self):
+        """After handler returning a value replaces the response."""
+        from starlette.responses import Response
+
+        def after_handler(resp):
+            return Response("replaced", status_code=200)
+
+        app = StarHTML(after=[after_handler])
+
+        @app.route("/test")
+        def handler():
+            return "original"
+
+        client = TestClient(app)
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert "replaced" in resp.text
+
+    def test_after_handler_with_request_param(self):
+        """After handler can also receive the request."""
+        seen = []
+
+        def after_handler(resp, req):
+            seen.append(req.url.path)
+
+        app = StarHTML(after=[after_handler])
+
+        @app.route("/check")
+        def handler():
+            return "ok"
+
+        client = TestClient(app)
+        client.get("/check")
+        assert seen == ["/check"]
+
+
+# ---------------------------------------------------------------------------
+# _add_route: method-name inference and index path (lines 400, 406)
+# ---------------------------------------------------------------------------
+
+
+class TestAddRouteMethodInference:
+    def test_function_named_as_http_method_infers_method(self):
+        """A function named 'get' with an explicit path infers GET method."""
+        app = StarHTML()
+
+        # Must use _add_route directly with a module-level-like function
+        # so nested_name returns just 'get'
+        def get():
+            return "items list"
+
+        # Override __qualname__ to simulate a module-level function
+        get.__qualname__ = "get"
+        app._add_route(get, "/items", methods=None, name=None, include_in_schema=True, body_wrap=None)
+
+        client = TestClient(app)
+        resp = client.get("/items")
+        assert resp.status_code == 200
+        assert "items list" in resp.text
+
+    def test_function_named_index_gets_root_path(self):
+        """A function named 'index' gets '/' as its path when path is None."""
+        app = StarHTML()
+
+        def index():
+            return "home"
+
+        index.__qualname__ = "index"
+        app._add_route(index, None, methods=None, name=None, include_in_schema=True, body_wrap=None)
+
+        client = TestClient(app)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert "home" in resp.text
+
+    def test_function_named_other_gets_function_name_path(self):
+        """A function with non-method name and no path gets /funcname."""
+        app = StarHTML()
+
+        def about():
+            return "about page"
+
+        about.__qualname__ = "about"
+        app._add_route(about, None, methods=None, name=None, include_in_schema=True, body_wrap=None)
+
+        client = TestClient(app)
+        resp = client.get("/about")
+        assert resp.status_code == 200
+        assert "about page" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# register_package_static: file serving, traversal protection (lines 466-479)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPackageStatic:
+    def test_serves_existing_file(self):
+        """Static file serving returns the file content."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "hello.txt").write_text("file content")
+
+            app = StarHTML()
+            # Clear previously registered packages to allow fresh registration
+            app._registered_packages.clear()
+            app.register_package_static("testpkg", tmpdir)
+
+            client = TestClient(app)
+            resp = client.get("/_pkg/testpkg/hello.txt")
+            assert resp.status_code == 200
+            assert resp.text == "file content"
+
+    def test_returns_404_for_missing_file(self):
+        """Static file serving returns 404 for nonexistent files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = StarHTML()
+            app._registered_packages.clear()
+            app.register_package_static("testpkg", tmpdir)
+
+            client = TestClient(app)
+            resp = client.get("/_pkg/testpkg/missing.txt")
+            assert resp.status_code == 404
+
+    def test_blocks_path_traversal(self):
+        """Static file serving blocks directory traversal attempts."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "ok.txt").write_text("ok")
+
+            app = StarHTML()
+            app._registered_packages.clear()
+            app.register_package_static("testpkg", tmpdir)
+
+            client = TestClient(app)
+            resp = client.get("/_pkg/testpkg/../../../etc/passwd")
+            assert resp.status_code in (403, 404)
+
+
+# ---------------------------------------------------------------------------
+# mount method (lines 489-494)
+# ---------------------------------------------------------------------------
+
+
+class TestMount:
+    def test_mount_inserts_before_catch_all(self):
+        """Mounted app is inserted before the catch-all static route."""
+
+        async def child_app(scope, receive, send):
+            resp = PlainTextResponse("mounted")
+            await resp(scope, receive, send)
+
+        app = StarHTML(static_path=".")
+        app.mount("/child", child_app)
+
+        client = TestClient(app)
+        resp = client.get("/child/")
+        assert resp.status_code == 200
+        assert resp.text == "mounted"
+
+    def test_mount_appends_when_no_catch_all(self):
+        """When there's no catch-all route, mount appends to the end."""
+
+        async def child_app(scope, receive, send):
+            resp = PlainTextResponse("appended")
+            await resp(scope, receive, send)
+
+        app = StarHTML()
+        # Remove any routes with {ext:...} pattern
+        app.router.routes = [r for r in app.router.routes if ".{ext:" not in getattr(r, "path", "")]
+        app.mount("/api", child_app)
+
+        client = TestClient(app)
+        resp = client.get("/api/")
+        assert resp.status_code == 200
+        assert resp.text == "appended"
+
+
+# ---------------------------------------------------------------------------
+# register_package with static_path and hdrs (lines 501, 503)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterPackage:
+    def test_register_package_with_hdrs_only(self):
+        """register_package with hdrs but no static_path adds headers."""
+        from starhtml.xtend import Script
+
+        app = StarHTML()
+        initial_count = len(app.hdrs)
+        app.register_package("mypkg", hdrs=[Script("console.log('hi')")])
+        assert len(app.hdrs) == initial_count + 1
+
+    def test_register_package_with_static_path_and_hdrs(self):
+        """register_package with both static_path and hdrs does both."""
+        from starhtml.xtend import Script
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            app = StarHTML()
+            app._registered_packages.clear()
+            initial_count = len(app.hdrs)
+            app.register_package("mypkg", static_path=tmpdir, hdrs=[Script("console.log('hi')")])
+            assert len(app.hdrs) == initial_count + 1
+            # Static route should exist
+            paths = [getattr(r, "path", "") for r in app.routes]
+            assert any("mypkg" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# _register_item dependencies (lines 519, 526-527)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterItemDependencies:
+    def test_item_with_dependencies_registers_dep_static(self):
+        """Items with get_dependencies() get their deps registered."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dep_path = Path(tmpdir) / "dep_static"
+            dep_path.mkdir()
+            Path(dep_path, "lib.js").write_text("// lib")
+
+            class ItemWithDeps:
+                def get_package_name(self):
+                    return "myitem"
+
+                def get_static_path(self):
+                    return None
+
+                def get_headers(self, pkg_prefix):
+                    return ()
+
+                def get_dependencies(self):
+                    return [("mydep", str(dep_path))]
+
+            app = StarHTML()
+            app._registered_packages.clear()
+            _register_item(app, ItemWithDeps())
+            assert "mydep" in app._registered_packages
+
+
+# ---------------------------------------------------------------------------
+# Duplicate plugin skip in register (line 570)
+# ---------------------------------------------------------------------------
+
+
+class TestDuplicatePluginSkip:
+    def test_registering_same_plugin_twice_skips_duplicate(self):
+        """Registering the same plugin twice does not duplicate it."""
+        from starhtml.plugins import persist
+
+        app = StarHTML()
+        app.register(persist)
+        plugin_count_after_first = len(app._registered_plugins)
+
+        app.register(persist)
+        assert len(app._registered_plugins) == plugin_count_after_first
+
+
+# ---------------------------------------------------------------------------
+# static_route method (lines 617-619)
+# ---------------------------------------------------------------------------
+
+
+class TestStaticRoute:
+    def test_static_route_serves_files(self):
+        """static_route creates a route that serves files with a given extension."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            Path(tmpdir, "data.json").write_text('{"key": "value"}')
+
+            app = StarHTML()
+            app.static_route(ext=".json", static_path=tmpdir)
+
+            client = TestClient(app)
+            resp = client.get("/data.json")
+            assert resp.status_code == 200
+            assert "key" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# devtools_json method (lines 628-635)
+# ---------------------------------------------------------------------------
+
+
+class TestDevtoolsJson:
+    def test_devtools_json_returns_workspace_info(self):
+        """devtools_json endpoint returns workspace root and uuid."""
+        app = StarHTML()
+        app.devtools_json(path="/my/project", uuid="test-uuid-123")
+
+        client = TestClient(app)
+        resp = client.get("/.well-known/appspecific/com.chrome.devtools.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["workspace"]["root"] == "/my/project"
+        assert data["workspace"]["uuid"] == "test-uuid-123"
+
+    def test_devtools_json_defaults(self):
+        """devtools_json generates defaults when path/uuid not provided."""
+        app = StarHTML()
+        app.devtools_json()
+
+        client = TestClient(app)
+        resp = client.get("/.well-known/appspecific/com.chrome.devtools.json")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "root" in data["workspace"]
+        assert "uuid" in data["workspace"]
+
+
+# ---------------------------------------------------------------------------
+# set_devtools_context in _endp (line 350)
+# ---------------------------------------------------------------------------
+
+
+class TestDevtoolsContext:
+    def test_devtools_flag_sets_context(self):
+        """When devtools=True, requests still work (context is set internally)."""
+        # We just verify the devtools path doesn't break request handling
+        app = StarHTML(devtools=True)
+
+        @app.route("/test")
+        def handler():
+            return "with devtools"
+
+        client = TestClient(app)
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert "with devtools" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# register import map for non-plugin items (line 595)
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterImportMap:
+    def test_item_with_import_map_merges_into_headers(self):
+        """Items providing get_import_map() have their mappings merged."""
+
+        class ItemWithImportMap:
+            def get_package_name(self):
+                return "mapped"
+
+            def get_static_path(self):
+                return None
+
+            def get_headers(self, pkg_prefix):
+                return ()
+
+            def get_import_map(self, prefix):
+                return {"my-lib": f"{prefix}/mapped/my-lib.js"}
+
+        app = StarHTML()
+        app.register(ItemWithImportMap())
+
+        # Check the import map header contains our mapping
+        import_maps = [h for h in app.hdrs if getattr(h, "attrs", {}).get("type") == "importmap"]
+        assert len(import_maps) == 1
+        content = str(import_maps[0])
+        assert "my-lib" in content

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -534,6 +534,48 @@ class TestFormSubmit:
         assert "data_on_submit" in spread
         assert "action" in spread
 
+    def test_reset_on_success_false_by_default(self):
+        [sig] = self._make_validated_signals("name")
+        result = form_submit("test", sig, name="t")
+        assert "data_on_signal_patch" not in result
+        assert "data-on-signal-patch-filter" not in result
+
+    def test_reset_on_success_adds_signal_patch_handler(self):
+        [sig] = self._make_validated_signals("name")
+        result = form_submit("test", sig, name="t", reset_on_success=True)
+        assert "data_on_signal_patch" in result
+        assert result["data-on-signal-patch-filter"] == "{include: /^t_submitted$/}"
+
+    def test_reset_on_success_guards_on_submitted(self):
+        [sig] = self._make_validated_signals("name")
+        result = form_submit("test", sig, name="t", reset_on_success=True)
+        js = result["data_on_signal_patch"].to_js()
+        assert "&&" in js
+        assert "$t_submitted" in js
+
+    def test_reset_on_success_resets_field_signals(self):
+        em, pw = self._make_validated_signals("email", "pw")
+        em.validate(email)
+        pw.validate(min_length, 8)
+        result = form_submit("test", em, pw, name="reg", reset_on_success=True)
+        js = result["data_on_signal_patch"].to_js()
+        assert "$email" in js
+        assert "$pw" in js
+
+    def test_reset_on_success_clears_error_signals(self):
+        [sig] = self._make_validated_signals("name")
+        result = form_submit("test", sig, name="t", reset_on_success=True)
+        js = result["data_on_signal_patch"].to_js()
+        assert "$name_err" in js
+
+    def test_reset_on_success_without_submitted_is_noop(self):
+        """When no submitted signal exists, reset_on_success has no effect."""
+        [sig] = self._make_validated_signals("name")
+        my_sub = Signal("sub", False)
+        result = form_submit("test", sig, submitting=my_sub, reset_on_success=True)
+        assert "data_on_signal_patch" not in result
+        assert "data-on-signal-patch-filter" not in result
+
 
 # ============================================================================
 # Native POST validation

--- a/tests/unit/test_lifespan.py
+++ b/tests/unit/test_lifespan.py
@@ -1,0 +1,205 @@
+"""Tests for the Lifespan class and lifecycle management."""
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+
+from starhtml import StarHTML, TestClient
+from starhtml.core import _run_handler
+
+
+class TestRunHandler:
+    def test_handler_no_params(self):
+        called = []
+
+        def handler():
+            called.append("ok")
+
+        asyncio.run(_run_handler(handler, app=None))
+        assert called == ["ok"]
+
+    def test_handler_receives_app(self):
+        called = []
+
+        def handler(app):
+            called.append(app)
+
+        sentinel = object()
+        asyncio.run(_run_handler(handler, sentinel))
+        assert called == [sentinel]
+
+    def test_async_handler(self):
+        called = []
+
+        async def handler():
+            called.append("async")
+
+        asyncio.run(_run_handler(handler, app=None))
+        assert called == ["async"]
+
+    def test_async_handler_with_app(self):
+        called = []
+
+        async def handler(app):
+            called.append(("async", app))
+
+        sentinel = object()
+        asyncio.run(_run_handler(handler, sentinel))
+        assert called == [("async", sentinel)]
+
+
+class TestLifespan:
+    def test_empty_lifespan(self):
+        app = StarHTML()
+        with TestClient(app):
+            pass
+
+    def test_runs_startup_shutdown(self):
+        events = []
+        app = StarHTML(on_startup=[lambda: events.append("startup")], on_shutdown=[lambda: events.append("shutdown")])
+        with TestClient(app):
+            assert events == ["startup"]
+        assert events == ["startup", "shutdown"]
+
+    def test_ordering_with_user_lifespan(self):
+        """Handlers run INSIDE user lifespan: enter -> startup -> yield -> shutdown -> exit."""
+        events = []
+
+        @asynccontextmanager
+        async def user_lifespan(app):
+            events.append("lifespan_enter")
+            yield
+            events.append("lifespan_exit")
+
+        app = StarHTML(
+            lifespan=user_lifespan,
+            on_startup=[lambda: events.append("startup")],
+            on_shutdown=[lambda: events.append("shutdown")],
+        )
+        with TestClient(app):
+            assert events == ["lifespan_enter", "startup"]
+        assert events == ["lifespan_enter", "startup", "shutdown", "lifespan_exit"]
+
+    def test_without_user_lifespan(self):
+        events = []
+        app = StarHTML(
+            on_startup=[lambda: events.append("startup")],
+            on_shutdown=[lambda: events.append("shutdown")],
+        )
+        with TestClient(app):
+            assert events == ["startup"]
+        assert events == ["startup", "shutdown"]
+
+    def test_handler_receives_app_param(self):
+        received = []
+
+        def on_startup(app):
+            received.append(app)
+
+        app = StarHTML(on_startup=[on_startup])
+        with TestClient(app):
+            pass
+        assert len(received) == 1
+        assert received[0] is app
+
+    def test_append_after_creation(self):
+        events = []
+        app = StarHTML()
+        app.add_lifecycle_handler("startup", lambda: events.append("dynamic_startup"))
+        app.add_lifecycle_handler("shutdown", lambda: events.append("dynamic_shutdown"))
+
+        with TestClient(app):
+            assert events == ["dynamic_startup"]
+        assert events == ["dynamic_startup", "dynamic_shutdown"]
+
+    def test_on_event_decorator(self):
+        events = []
+        app = StarHTML()
+
+        @app.on_event("startup")
+        def on_startup():
+            events.append("startup")
+
+        @app.on_event("shutdown")
+        def on_shutdown():
+            events.append("shutdown")
+
+        with TestClient(app):
+            assert events == ["startup"]
+        assert events == ["startup", "shutdown"]
+
+    def test_async_startup_handler(self):
+        events = []
+
+        async def async_startup():
+            events.append("async_startup")
+
+        app = StarHTML(on_startup=[async_startup])
+        with TestClient(app):
+            assert events == ["async_startup"]
+
+    def test_async_shutdown_handler(self):
+        events = []
+
+        async def async_shutdown():
+            events.append("async_shutdown")
+
+        app = StarHTML(on_shutdown=[async_shutdown])
+        with TestClient(app):
+            pass
+        assert events == ["async_shutdown"]
+
+    def test_async_handler_with_app_param(self):
+        received = []
+
+        async def async_startup(app):
+            received.append(app)
+
+        app = StarHTML(on_startup=[async_startup])
+        with TestClient(app):
+            pass
+        assert len(received) == 1
+        assert received[0] is app
+
+    def test_mixed_sync_async_handlers(self):
+        events = []
+
+        def sync_handler():
+            events.append("sync")
+
+        async def async_handler():
+            events.append("async")
+
+        app = StarHTML(on_startup=[sync_handler, async_handler])
+        with TestClient(app):
+            assert events == ["sync", "async"]
+
+    def test_startup_exception_propagates(self):
+        class StartupError(Exception):
+            pass
+
+        def bad_startup():
+            raise StartupError("startup failed")
+
+        app = StarHTML(on_startup=[bad_startup])
+        with pytest.raises(StartupError, match="startup failed"):
+            with TestClient(app, raise_server_exceptions=True):
+                pass
+
+    def test_multiple_handlers_order_preserved(self):
+        events = []
+        app = StarHTML(
+            on_startup=[
+                lambda: events.append("first"),
+                lambda: events.append("second"),
+                lambda: events.append("third"),
+            ],
+            on_shutdown=[
+                lambda: events.append("close_first"),
+                lambda: events.append("close_second"),
+            ],
+        )
+        with TestClient(app):
+            assert events == ["first", "second", "third"]
+        assert events == ["first", "second", "third", "close_first", "close_second"]

--- a/tests/unit/test_register.py
+++ b/tests/unit/test_register.py
@@ -1,8 +1,10 @@
 """Tests for app.register() unified registration method."""
 
+from contextlib import asynccontextmanager
+
 import pytest
 
-from starhtml import StarHTML
+from starhtml import StarHTML, TestClient
 from starhtml.plugins import Plugin, canvas, persist, scroll, split
 
 
@@ -259,3 +261,64 @@ class TestRegisterIntegration:
         assert str(main.sizes) == "$main_sizes"
         assert str(sidebar.position) == "$sidebar_position"
         assert str(sidebar.sizes) == "$sidebar_sizes"
+
+    def test_register_wires_item_lifecycle_hooks(self):
+        events = []
+        app = StarHTML()
+
+        class RegistrableWithLifecycle:
+            def get_package_name(self):
+                return "lifecycle"
+
+            def get_static_path(self):
+                return None
+
+            def get_headers(self, pkg_prefix):
+                return ()
+
+            def on_startup(self, app):
+                events.append(("startup", app))
+
+            def on_shutdown(self, app):
+                events.append(("shutdown", app))
+
+        app.register(RegistrableWithLifecycle())
+
+        with TestClient(app):
+            assert events == [("startup", app)]
+
+        assert events == [("startup", app), ("shutdown", app)]
+
+    def test_register_lifecycle_wraps_existing_lifespan(self):
+        events = []
+
+        @asynccontextmanager
+        async def lifespan(app):
+            events.append("lifespan_enter")
+            yield
+            events.append("lifespan_exit")
+
+        app = StarHTML(lifespan=lifespan)
+
+        class RegistrableWithStartup:
+            def get_package_name(self):
+                return "wrapped"
+
+            def get_static_path(self):
+                return None
+
+            def get_headers(self, pkg_prefix):
+                return ()
+
+            def on_startup(self, app):
+                events.append("startup")
+
+            def on_shutdown(self, app):
+                events.append("shutdown")
+
+        app.register(RegistrableWithStartup())
+
+        with TestClient(app):
+            assert events == ["lifespan_enter", "startup"]
+
+        assert events == ["lifespan_enter", "startup", "shutdown", "lifespan_exit"]

--- a/tests/unit/test_relay_stream.py
+++ b/tests/unit/test_relay_stream.py
@@ -2,6 +2,8 @@
 
 import asyncio
 
+import pytest
+
 from starhtml.realtime import (
     SSE_KEEPALIVE,
     Relay,
@@ -285,18 +287,74 @@ class TestStreamSseItemsStringPassthrough:
 
 
 class TestInstallApp:
-    def test_install_registers_shutdown_handler(self):
-        """relay.install(app) registers shutdown so relay.shutdown() is called on app exit."""
+    def test_install_uses_internal_lifecycle_handler(self):
         calls = []
 
         class FakeApp:
-            def add_event_handler(self, event, handler):
+            def add_lifecycle_handler(self, event, handler):
                 calls.append((event, handler))
 
         relay = Relay()
         relay.install(FakeApp())
+
         assert len(calls) == 1
         assert calls[0][0] == "shutdown"
-        # Calling the registered handler should shut down the relay
         calls[0][1]()
         assert relay._closed is True
+
+    def test_install_wraps_server_exit_before_original_handler(self):
+        events = []
+
+        class FakeApp:
+            def add_lifecycle_handler(self, event, handler): ...
+
+        class FakeServer:
+            def handle_exit(self, sig, frame):
+                events.append(("server", sig, frame))
+
+        class TestRelay(Relay):
+            def shutdown(self):
+                events.append(("relay", None, None))
+
+        relay = TestRelay()
+        server = FakeServer()
+
+        relay.install(FakeApp(), server=server)
+        server.handle_exit("SIGTERM", "frame")
+
+        assert events == [("relay", None, None), ("server", "SIGTERM", "frame")]
+
+    def test_install_does_not_double_wrap_server_exit(self):
+        calls = []
+
+        class FakeApp:
+            def add_lifecycle_handler(self, event, handler):
+                calls.append((event, handler))
+
+        class FakeServer:
+            def __init__(self):
+                self.count = 0
+
+            def handle_exit(self, sig, frame):
+                self.count += 1
+
+        shutdowns = []
+
+        class TestRelay(Relay):
+            def shutdown(self):
+                shutdowns.append("shutdown")
+
+        relay = TestRelay()
+        server = FakeServer()
+
+        relay.install(FakeApp(), server=server)
+        relay.install(FakeApp(), server=server)
+        server.handle_exit("SIGTERM", None)
+
+        assert server.count == 1
+        assert shutdowns == ["shutdown"]
+
+    def test_install_raises_on_unsupported_app(self):
+        relay = Relay()
+        with pytest.raises(AttributeError, match="must support add_lifecycle_handler"):
+            relay.install(object())

--- a/tests/unit/test_star_route.py
+++ b/tests/unit/test_star_route.py
@@ -1,0 +1,198 @@
+"""Tests for StarRoute — Route subclass with StarHTML's _endp processing."""
+
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+from starhtml import Div, Mount, StarHTML, StarRoute, TestClient
+
+
+class TestStarRouteBasic:
+    def test_with_app_immediate_binding(self):
+        app = StarHTML()
+
+        def handler():
+            return "hello"
+
+        route = StarRoute("/test", handler, app=app)
+        assert route._bound is True
+        assert isinstance(route, Route)
+
+    def test_without_app_deferred(self):
+        def handler():
+            return "hello"
+
+        route = StarRoute("/test", handler)
+        assert route._bound is False
+        assert route.path == "/test"
+        assert route.methods is not None
+        assert "GET" in route.methods
+        assert "POST" in route.methods
+
+    def test_default_methods(self):
+        route = StarRoute("/test", lambda: None)
+        assert route.methods is not None
+        assert "GET" in route.methods
+        assert "POST" in route.methods
+
+    def test_explicit_methods(self):
+        route = StarRoute("/test", lambda: None, methods=["DELETE"])
+        assert route.methods is not None
+        assert "DELETE" in route.methods
+
+    def test_isinstance_route(self):
+        route = StarRoute("/test", lambda: None)
+        assert isinstance(route, Route)
+
+
+class TestStarRouteServing:
+    def test_serves_string_response(self):
+        app = StarHTML()
+        route = StarRoute("/hello", lambda: "world", app=app)
+        app.add_route(route)
+
+        client = TestClient(app)
+        resp = client.get("/hello")
+        assert resp.status_code == 200
+        assert "world" in resp.text
+
+    def test_ft_rendering(self):
+        """Handler returning FT objects renders to HTML."""
+        app = StarHTML()
+
+        def handler():
+            return Div("content", cls="test")
+
+        route = StarRoute("/ft", handler, app=app)
+        app.add_route(route)
+
+        client = TestClient(app)
+        resp = client.get("/ft")
+        assert resp.status_code == 200
+        assert '<div class="test">content</div>' in resp.text
+
+    def test_param_extraction(self):
+        """Path and query params are extracted correctly."""
+        app = StarHTML()
+
+        def handler(name: str):
+            return f"hello {name}"
+
+        route = StarRoute("/greet/{name}", handler, app=app)
+        app.add_route(route)
+
+        client = TestClient(app)
+        resp = client.get("/greet/world")
+        assert resp.status_code == 200
+        assert "hello world" in resp.text
+
+    def test_beforeware_runs(self):
+        """Beforeware executes on StarRoute handlers."""
+        called = []
+
+        def before(req):
+            called.append("before")
+
+        app = StarHTML(before=[before])
+
+        route = StarRoute("/test", lambda: "ok", app=app)
+        app.add_route(route)
+
+        client = TestClient(app)
+        resp = client.get("/test")
+        assert resp.status_code == 200
+        assert called == ["before"]
+
+
+class TestStarRouteInMount:
+    def test_in_mount_with_app(self):
+        """StarRoute inside Mount serves correctly when pre-bound."""
+        app = StarHTML(
+            routes=[
+                Mount(
+                    "/api",
+                    routes=[
+                        StarRoute("/users", lambda: "user list", app=None),
+                    ],
+                ),
+            ]
+        )
+        # Auto-binding happens in __init__
+        client = TestClient(app)
+        resp = client.get("/api/users")
+        assert resp.status_code == 200
+        assert "user list" in resp.text
+
+    def test_mixed_with_plain_route(self):
+        """StarRoute and plain Starlette Route coexist in same Mount."""
+
+        async def plain_handler(request):
+            return PlainTextResponse("plain")
+
+        app = StarHTML(
+            routes=[
+                Mount(
+                    "/api",
+                    routes=[
+                        StarRoute("/star", lambda: "star response", app=None),
+                        Route("/plain", plain_handler),
+                    ],
+                ),
+            ]
+        )
+
+        client = TestClient(app)
+
+        resp_star = client.get("/api/star")
+        assert resp_star.status_code == 200
+        assert "star response" in resp_star.text
+
+        resp_plain = client.get("/api/plain")
+        assert resp_plain.status_code == 200
+        assert resp_plain.text == "plain"
+
+
+class TestStarRouteDeferredBinding:
+    def test_deferred_in_routes_list(self):
+        """StarRoute without app is auto-bound when passed in routes=[]."""
+
+        def handler():
+            return "deferred"
+
+        app = StarHTML(routes=[StarRoute("/deferred", handler)])
+
+        client = TestClient(app)
+        resp = client.get("/deferred")
+        assert resp.status_code == 200
+        assert "deferred" in resp.text
+
+    def test_deferred_in_mount(self):
+        """StarRoute without app inside Mount is auto-bound by StarHTML."""
+
+        def handler():
+            return "nested deferred"
+
+        app = StarHTML(
+            routes=[
+                Mount("/sub", routes=[StarRoute("/item", handler)]),
+            ]
+        )
+
+        client = TestClient(app)
+        resp = client.get("/sub/item")
+        assert resp.status_code == 200
+        assert "nested deferred" in resp.text
+
+    def test_via_add_route(self):
+        """app.add_route(StarRoute(...)) auto-binds."""
+        app = StarHTML()
+
+        route = StarRoute("/dynamic", lambda: "added")
+        assert route._bound is False
+
+        app.add_route(route)
+        assert route._bound is True
+
+        client = TestClient(app)
+        resp = client.get("/dynamic")
+        assert resp.status_code == 200
+        assert "added" in resp.text

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.5.19"
+version = "0.5.24"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -1146,6 +1146,7 @@ test = [
 dev = [
     { name = "psutil" },
     { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
     { name = "python-multipart" },
 ]
 
@@ -1176,7 +1177,7 @@ requires-dist = [
     { name = "star-drawing", marker = "extra == 'demo'", specifier = ">=0.1.0" },
     { name = "starelements", marker = "extra == 'debug'", specifier = ">=0.1.1" },
     { name = "starelements", marker = "extra == 'demo'", specifier = ">=0.1.1" },
-    { name = "starlette" },
+    { name = "starlette", specifier = "~=1.0" },
     { name = "starlette-compress", specifier = ">=1.0.0" },
     { name = "starlighter", marker = "extra == 'demo'" },
     { name = "uvicorn", extras = ["standard"] },
@@ -1187,19 +1188,21 @@ provides-extras = ["test", "dev", "debug", "demo"]
 dev = [
     { name = "psutil", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.1.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "python-multipart", specifier = ">=0.0.20" },
 ]
 
 [[package]]
 name = "starlette"
-version = "0.47.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/d0/0332bd8a25779a0e2082b0e179805ad39afad642938b371ae0882e7f880d/starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af", size = 2582856, upload-time = "2025-05-29T15:45:27.628Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/81/c60b35fe9674f63b38a8feafc414fca0da378a9dbd5fa1e0b8d23fcc7a9b/starlette-0.47.0-py3-none-any.whl", hash = "sha256:9d052d4933683af40ffd47c7465433570b4949dc937e20ad1d73b34e72f10c37", size = 72796, upload-time = "2025-05-29T15:45:26.305Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]

--- a/web/API.md
+++ b/web/API.md
@@ -468,7 +468,7 @@ data_effect=[
 data_effect=is_form_complete.then(auto_save_data)
 
 # API calls on signal changes
-data_effect=search_query.length >= 3 & post("/api/search", q=search_query)
+data_effect=search_query.length >= 3 & post("/api/search")
 ```
 
 **Key Differences:**
@@ -477,21 +477,92 @@ data_effect=search_query.length >= 3 & post("/api/search", q=search_query)
 
 ### HTTP Actions
 
+Use `get()`, `post()`, `put()`, `patch()`, and `delete()` to make requests from the browser.
+
+**Important:** Datastar automatically sends **all signals** as the request body. You don't pass user data as keyword arguments — your server-side route handler receives every signal value by default.
+
 ```python
-# Simple requests
+# All signal values are sent automatically — no need to specify data
 data_on_click=get("/api/data")
 data_on_click=post("/api/submit")
-data_on_click=delete(f"/api/items/{item_id}")
-
-# With parameters
-data_on_click=get("/api/search", q=search_term)
-data_on_click=post("/api/contact", name=name, email=email)
+data_on_click=delete(f"/api/items/{item_id}")  # item_id is a Python variable baked into the URL at render time
 
 # Conditional requests
-data_on_click=is_valid.then(post("/api/submit", data=form_data))
+data_on_click=is_valid.then(post("/api/submit"))
+```
+
+**Sending specific data instead of all signals:**
+
+Use the `payload` option to send only certain values. Use `js()` to reference browser-side values (like DOM events or element properties) that don't exist in Python:
+
+```python
+# Send only "text" — derived from a browser-side DOM value
+data_on_blur=post("/api/edit", payload={"text": js("evt.target.innerText.trim()")})
+```
+
+**Action options:**
+
+All keyword arguments are [Datastar action options](https://data-star.dev/reference/action_plugins/backend), not user data. Available options include `contentType`, `headers`, `payload`, `selector`, `filterSignals`, and others.
+
+```python
+# Set content type for form submissions
+data_on_click=post("/api/submit", contentType="form")
+
+# Send only signals whose names match a regex
+data_on_click=post("/api/submit", filterSignals="name|email")
 ```
 
 ## Advanced Features
+
+### Startup & Shutdown
+
+Run code when your app starts (connect to a database, warm a cache) or stops (close connections, flush logs). There are four ways to register these handlers — pick whichever fits your situation.
+
+**Constructor lists** — simplest for quick setup:
+
+```python
+app, rt = star_app(
+    on_startup=[init_db, warm_cache],
+    on_shutdown=[close_db],
+)
+```
+
+**Lifespan context manager** — best when startup and shutdown are paired (e.g. open/close the same resource):
+
+```python
+from contextlib import asynccontextmanager
+
+@asynccontextmanager
+async def lifespan(app):
+    db = await connect_db()
+    yield
+    await db.close()
+
+app, rt = star_app(lifespan=lifespan)
+```
+
+**Decorator** — register handlers after creating the app:
+
+```python
+@app.on_event("startup")
+async def init_db():
+    ...
+
+@app.on_event("shutdown")
+def cleanup():
+    ...
+```
+
+**Programmatic** — useful when handlers come from plugins or configuration:
+
+```python
+app.add_lifecycle_handler("startup", init_db)
+app.add_lifecycle_handler("shutdown", close_db)
+```
+
+All handlers can be sync or async, and can optionally accept the `app` instance as a parameter.
+
+**Combining approaches**: You can use a lifespan context manager *and* individual handlers together. The handlers run inside the lifespan context, so they can access any resources it initializes (e.g. a database connection created in the lifespan is available to startup handlers).
 
 ### Slot Attributes System
 
@@ -811,170 +882,160 @@ data_on_input=(search, {"debounce": 300})             # Wait 300ms after typing
 ```python
 from starhtml import *
 
-def contact_form():
-    return Form(
-        H2("Contact Us"),
-        
-        # Name field with inline signal definition
-        Div(
-            Label("Name", for_="name"),
-        Input(
-                (name := Signal("name", "")),         # Define signal inline
-                type="text",
-                id="name",
-            data_bind=name,
-                data_on_input=(name_error := Signal("name_error", "")).set(
-                switch([
-                        (~name, "Name is required"),
-                        (name.length < 2, "Name too short")
-                    ], default="")
-                ),
-                cls="form-input",
-            data_class_error=name_error
-        ),
-            Span(data_text=name_error, data_show=name_error, cls="error-text")
-        ),
-        
-        # Email field with inline signal definition
-        Div(
-            Label("Email", for_="email"),
-        Input(
-                (email := Signal("email", "")),       # Define signal inline
-            type="email",
-                id="email", 
-            data_bind=email,
-                data_on_input=(email_error := Signal("email_error", "")).set(
-                    switch([
-                        (~email, "Email is required"),
-                        (~email.contains("@"), "Invalid email format")
-                    ], default="")
-                ),
-                cls="form-input",
-                data_class_error=email_error
+app, rt = star_app()
+
+@rt("/")
+def home():
+    # Create signals for each form field
+    name = Signal("name", "")
+    em = Signal("email", "")
+    message = Signal("message", "")
+
+    # .validate() attaches a validation rule and returns attrs
+    # (data-bind, blur/input handlers, aria-invalid) to spread into the Input
+    name_v = name.validate(min_length, 2, "Name")
+    em_v = em.validate(email)
+
+    # form_submit() wires everything together:
+    #   - Runs all validations on submit, POSTs only if all pass
+    #   - Auto-creates contact_submitting / contact_submitted / contact_error signals
+    #   - reset_on_success clears listed signals after a successful submit
+    # Only validated signals need to be listed here — message has no rules.
+    fs = form_submit("/submit", name, em, name="contact", reset_on_success=True)
+
+    return Div(
+        name, em, message,   # Place signals to emit their data-signals attrs
+
+        Form(
+            fs,              # FormAttrs dict — sets action, method, data-on-submit, etc.
+
+            # Spread name_v into Input to get two-way binding + validation
+            Div(
+                Label("Name", fr="name"),
+                Input(name_v, type="text", id="name", name="name", cls="form-input"),
+                # name.err is the auto-created error signal (empty string = no error)
+                Span(data_text=name.err, data_show=name.err, cls="error-text"),
             ),
-            Span(data_text=email_error, data_show=email_error, cls="error-text")
+
+            # Email field — same pattern
+            Div(
+                Label("Email", fr="email"),
+                Input(em_v, type="email", id="email", name="email", cls="form-input"),
+                Span(data_text=em.err, data_show=em.err, cls="error-text"),
+            ),
+
+            # Message — no validation, just two-way binding via data_bind
+            Div(
+                Label("Message", fr="message"),
+                Textarea(data_bind=message, id="message", name="message", rows="4", cls="form-input"),
+            ),
+
+            # fs.submitting is a Signal — use it for loading state
+            Button(
+                data_text=fs.submitting.if_("Sending...", "Send Message"),
+                type="submit",
+                data_attr_disabled=fs.submitting,
+                cls="btn btn-primary",
+            ),
         ),
-        
-        # Message field
-        Div(
-            Label("Message", for_="message"),
-        Textarea(
-                (message := Signal("message", "")),   # Define signal inline
-                id="message",
-            data_bind=message,
-                rows="4",
-                cls="form-input"
-            )
-        ),
-        
-        # Submit button
-        Button(
-            (is_submitting := Signal("is_submitting", False)),  # Define inline
-            data_text=is_submitting.if_("Sending...", "Send Message"),
-            type="submit",
-            data_attr_disabled=is_submitting | name_error | email_error | ~all(name, email, message),
-            cls="btn btn-primary"
-        ),
-        
-        # Form submission
-        data_on_submit=([
-            is_submitting.set(True),
-            post("/api/contact", name=name, email=email, message=message)
-        ], {"prevent": True}),
-        
-        cls="contact-form"
+        cls="contact-form",
     )
+
+@rt("/submit", methods=["POST"])
+@sse
+async def submit_form(name: str = "", email: str = "", message: str = ""):
+    import asyncio
+    # Show loading state on the button
+    yield signals(contact_submitting=True)
+    await asyncio.sleep(0.5)  # Simulate work
+    # End loading and mark success — reset_on_success will clear the form
+    yield signals(contact_submitting=False, contact_submitted=True)
 ```
 
 ### Chat with Server-Sent Events (SSE)
 
 ```python
 from starhtml import *
+import time
 
 def chat_app():
+    message = Signal("message", "")
+    sending = Signal("sending", False)
+
     return Div(
+        message, sending,  # Signals render as hidden setup attributes
+        
         H1("Live Chat"),
         
         # Messages container
-        Div(
-            id="messages",
-            cls="messages-container"
-        ),
+        Div(id="messages", cls="messages-container"),
         
         # Chat input form
         Form(
             Input(
-                (message := Signal("message", "")),
-                (sending := Signal("sending", False)),
                 placeholder="Type your message...",
-                data_bind=message,
-                data_attr_disabled=sending,
+                data_bind=message,           # Two-way bind to message signal
+                data_attr_disabled=sending,   # Disable while sending
                 cls="message-input"
             ),
             
             Button(
                 data_text=sending.if_("Sending...", "Send"),
                 type="submit",
-                data_attr_disabled=sending | ~message,
+                data_attr_disabled=sending | ~message,  # Disabled when sending or empty
                 cls="send-button"
             ),
             
-            # Submit triggers SSE endpoint
-            data_on_submit=(post("/chat/send", text=message), {"prevent": True}),
+            # post() sends all current signal values to the server
+            data_on_submit=(post("/chat/send"), {"prevent": True}),
             cls="chat-form"
         ),
         
         cls="chat-app"
     )
 
-# SSE endpoint for sending messages
+# @sse makes the handler yield SSE events instead of returning a response
 @rt("/chat/send", methods=["POST"])
 @sse
-def send_message(message: str = ""):
-    import time
-    
-    # Show sending state
+def send_message(message: str = ""):  # Signal values arrive as parameters
+    # Update sending signal on the client
     yield signals(sending=True)
     
-    # Simulate message processing
-    time.sleep(0.5)
+    time.sleep(0.5)  # Simulated delay
     
-    # Add message to chat
-    message_element = Div(
-        Span("You", cls="username"),
-        Span(message, cls="message-text"),
-        Span(time.strftime("%H:%M"), cls="timestamp"),
-        cls="message user-message"
+    # Append user message to chat
+    yield elements(
+        Div(
+            Span("You", cls="username"),
+            Span(message, cls="message-text"),
+            Span(time.strftime("%H:%M"), cls="timestamp"),
+            cls="message user-message"
+        ),
+        "#messages", "append"
     )
     
-    # Append new message to chat
-    yield elements(message_element, "#messages", "append")
+    time.sleep(1)  # Simulated delay
     
-    # Simulate server response
-    time.sleep(1)
-    
-    # Add bot response
-    bot_response = Div(
-        Span("Bot", cls="username"),
-        Span(f"Echo: {message}", cls="message-text"),
-        Span(time.strftime("%H:%M"), cls="timestamp"),
-        cls="message bot-message"
+    # Append bot response
+    yield elements(
+        Div(
+            Span("Bot", cls="username"),
+            Span(f"Echo: {message}", cls="message-text"),
+            Span(time.strftime("%H:%M"), cls="timestamp"),
+            cls="message bot-message"
+        ),
+        "#messages", "append"
     )
     
-    yield elements(bot_response, "#messages", "append")
-    
-    # Clear form and reset state
-    yield signals(
-        message="",      # Clear input
-        sending=False    # Reset sending state
-    )
+    # Clear input and reset sending state
+    yield signals(message="", sending=False)
 
-# ⚠️ SSE Best Practice: When replacing elements (not appending), 
-# always preserve id attributes to allow future targeting:
-# 
+# ⚠️ SSE Best Practice: When replacing elements (not appending),
+# preserve the id so the selector keeps working for future updates:
+#
 # yield elements(
 #     Div("New content", id="messages", cls="messages-container"),
-#     "#messages"  # ← Same id preserved in replacement
+#     "#messages"  # Replacement still has id="messages"
 # )
 ```
 

--- a/web/demos/03_forms_binding.py
+++ b/web/demos/03_forms_binding.py
@@ -66,7 +66,11 @@ def home():
         Div(
             H2("Contact Information", cls="text-2xl font-bold text-black mb-8"),
             Form(
-                (fs := form_submit("submit", name, em, age, phone, name="contact", submitted=submitted)),
+                (
+                    fs := form_submit(
+                        "submit", name, em, age, phone, name="contact", submitted=submitted, reset_on_success=True
+                    )
+                ),
                 # Name
                 Div(
                     Label(
@@ -236,18 +240,7 @@ async def submit_form(req, name: str = "", email: str = "", age: str = "", phone
     if errors:
         yield signals(contact_submitting=False, **errors)
     else:
-        yield signals(
-            contact_submitting=False,
-            contact_submitted=True,
-            name="",
-            email="",
-            age="",
-            phone="",
-            name_err="",
-            email_err="",
-            age_err="",
-            phone_err="",
-        )
+        yield signals(contact_submitting=False, contact_submitted=True)
         await asyncio.sleep(3)
         yield signals(contact_submitted=False)
 

--- a/web/demos/07_todo_list.py
+++ b/web/demos/07_todo_list.py
@@ -1,11 +1,8 @@
-"""Todo List MVC - Bold & Improved with working Datastar patterns"""
-
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 
 from starhtml import *
 from starhtml.plugins import persist
 
-# Bold app configuration
 app, rt = star_app(
     title="✨ Todo List",
     htmlkw={"lang": "en"},
@@ -19,24 +16,14 @@ app, rt = star_app(
 
 app.register(persist())
 
-# ============================================================================
-#  Todo Data Model
-# ============================================================================
-
 
 @dataclass
 class Todo:
-    """Todo item with serialization support."""
-
     id: int
     text: str
     completed: bool = False
 
-    def to_dict(self):
-        return asdict(self)
 
-
-# In-memory storage (in production, use a database)
 todos_store: list[Todo] = [
     Todo(1, "Learn Datastar patterns", False),
     Todo(2, "Build a clean todo app", False),
@@ -44,13 +31,8 @@ todos_store: list[Todo] = [
 ]
 next_id = 4
 
-# ============================================================================
-#  Components
-# ============================================================================
-
 
 def render_todo_item(todo: Todo, active_filter: Signal):
-    """Render a single todo item with bold styling."""
     is_completed = expr(todo.completed)
 
     show_condition = (
@@ -60,7 +42,6 @@ def render_todo_item(todo: Todo, active_filter: Signal):
     )
 
     return Div(
-        # Checkbox button
         Button(
             Icon(
                 "mdi:checkbox-marked" if todo.completed else "mdi:checkbox-blank-outline",
@@ -69,21 +50,18 @@ def render_todo_item(todo: Todo, active_filter: Signal):
             data_on_click=post(f"todos/{todo.id}/toggle"),
             cls="checkbox-button p-3 rounded-xl transition-all",
         ),
-        # Todo text - bold contenteditable
         Div(
             todo.text,
-            data_on_blur=post(f"todos/{todo.id}/edit", text="evt.target.innerText.trim()"),
+            data_on_blur=post(f"todos/{todo.id}/edit", payload={"text": js("evt.target.innerText.trim()")}),
             contenteditable="true",
             style="white-space: pre-wrap;",
             cls="todo-text flex-1 px-4 py-3 rounded-xl cursor-text font-semibold text-gray-800 hover:bg-gray-50",
         ),
-        # Delete button
         Button(
             Icon("lucide:trash-2", cls="icon-sm"),
             data_on_click=delete(f"todos/{todo.id}"),
             cls="delete-btn p-3 rounded-xl transition-all",
         ),
-        # Container attributes with visibility
         cls="todo-item slide-in flex items-center gap-3 p-2 mb-3",
         data_class_todo_completed=is_completed,
         data_todo_id=str(todo.id),
@@ -92,7 +70,6 @@ def render_todo_item(todo: Todo, active_filter: Signal):
 
 
 def render_empty_state():
-    """Render bold empty state message."""
     return Div(
         Icon("lucide:sparkles", cls="text-6xl mx-auto mb-6 text-purple-400"),
         H3("No todos yet!", cls="text-2xl font-black text-gray-800 mb-3"),
@@ -108,7 +85,6 @@ def render_filter_button(
     count: int | Expr | Signal | None = None,
     active_filter: Signal | None = None,
 ):
-    """Render a pill-shaped tab button."""
     return Button(
         Span(
             Span(full_label, cls="hidden sm:inline"),
@@ -118,37 +94,28 @@ def render_filter_button(
             cls="ml-2 min-w-[24px] h-6 px-1.5 flex items-center justify-center text-xs rounded-full font-bold transition-all bg-purple-200 text-purple-700",
             data_class_counter_active=active_filter == filter_value,
             data_text=count,
-            data_show=count > 0,  # Show counter only when count > 0
+            data_show=count > 0,
         )
         if count is not None
-        else None,  # Always include the span if count is provided
+        else None,
         data_on_click=active_filter.set(filter_value),
         cls="filter-btn px-6 py-3 text-sm font-semibold rounded-full transition-all duration-200 flex items-center justify-center",
         data_class_active=active_filter == filter_value,
     )
 
 
-# ============================================================================
-#  Main Page
-# ============================================================================
-
-
 @rt("/")
 def home():
-    """Bold todo app home page."""
-    # Calculate actual values from Python data
     completed = sum(1 for todo in todos_store if todo.completed)
     total = len(todos_store)
     initial_progress = round((completed / total * 100) if total > 0 else 0)
 
     return Div(
-        # Only signals for UI state and counts - NOT the actual todo data
         (todo_text := Signal("todo_text", "")),
         (active_filter := Signal("active_filter", "all")),
         (total_count := Signal("total_count", total)),
         (completed_count := Signal("completed_count", completed)),
         (active_count := Signal("active_count", total - completed)),
-        # Computed signals for derived state and validation
         (
             progress_percent := Signal(
                 "progress_percent", js("Math.round($completed_count / Math.max($total_count, 1) * 100)")
@@ -161,16 +128,13 @@ def home():
             )
         ),
         (can_add_todo := Signal("can_add_todo", js("$todo_text.trim().length > 0 && !$todo_error"))),
-        # Hero Header
         Header(
             H1("✨ Todo Conqueror", cls="hero-text text-6xl font-black mb-4"),
             P("Dominate your tasks", cls="text-xl font-semibold text-gray-600"),
             cls="text-center py-12 mb-8",
         ),
-        # Main container
         Main(
             Div(
-                # Chunky progress bar
                 Div(
                     Div(
                         Div(
@@ -190,9 +154,7 @@ def home():
                     ),
                     cls="mb-8 opacity-80",
                 ),
-                # Combined todo management section
                 Div(
-                    # Add todo form (now inside the list container)
                     Div(
                         Form(
                             Div(
@@ -203,9 +165,8 @@ def home():
                                     cls="bold-input flex-1 px-6 py-4 text-lg font-semibold resize-none overflow-hidden",
                                     style="field-sizing: content; min-height: 3.5rem; max-height: 10rem;",
                                     data_bind=todo_text,
-                                    # Enter submits (but not Shift+Enter for newlines)
                                     data_on_keydown=js(
-                                        "if(evt.key === 'Enter' && !evt.shiftKey) { evt.preventDefault(); if($can_add_todo) { @post('todos/add', {todo_text: $todo_text}); } }"
+                                        "if(evt.key === 'Enter' && !evt.shiftKey) { evt.preventDefault(); if($can_add_todo) { @post('todos/add'); } }"
                                     ),
                                 ),
                                 Button(
@@ -213,12 +174,11 @@ def home():
                                     "Add",
                                     type="button",
                                     cls="bold-button px-6 py-4 text-lg font-bold text-white flex items-center",
-                                    data_on_click=post("todos/add", todo_text=todo_text),
+                                    data_on_click=post("todos/add"),
                                     data_attr_disabled=~can_add_todo,
                                 ),
                                 cls="flex gap-4",
                             ),
-                            # Character count
                             Div(
                                 Span(
                                     cls="text-red-500 text-sm font-medium",
@@ -228,7 +188,6 @@ def home():
                                 Span(
                                     cls="text-sm font-medium ml-auto text-gray-500",
                                     data_text=todo_text.length + "/200",
-                                    # Color based on length thresholds
                                     data_attr_class=switch(
                                         [
                                             (todo_text.length > 200, "text-red-500"),
@@ -242,7 +201,6 @@ def home():
                         ),
                         cls="border-b border-gray-200 pb-6 mb-6",
                     ),
-                    # Filter buttons (now connected to list)
                     Div(
                         Div(
                             render_filter_button("All Quests", "All", "all", total_count, active_filter),
@@ -252,16 +210,12 @@ def home():
                         ),
                         cls="flex justify-center mb-6",
                     ),
-                    # Todo list container
                     Div(
-                        # Render all todos - visibility controlled by filter in each item
                         *[render_todo_item(todo, active_filter) for todo in todos_store],
-                        # Empty state - show when no todos exist
                         render_empty_state() if not todos_store else None,
                         id="todo-list",
                         cls="min-h-[200px]",
                     ),
-                    # Clear completed button
                     Div(
                         Button(
                             Icon("lucide:trash", cls="text-xl mr-3"),
@@ -279,7 +233,6 @@ def home():
             ),
             cls="container mx-auto px-6 py-8",
         ),
-        # Stats Footer - Appears at bottom of content
         Div(
             Div(
                 Div(
@@ -309,67 +262,42 @@ def home():
             ),
             cls="stats-footer",
         ),
-        # All keyword arguments must go at the end
         cls="min-h-screen",
     )
-
-
-# ============================================================================
-#  SSE Endpoints
-# ============================================================================
 
 
 @rt("/todos/add", methods=["POST"])
 @sse
 def add_todo(req, todo_text: str = "", active_filter: Signal = None):
-    """Add a new todo - simplified."""
     global next_id
-
-    # Get text from parameter
     text = todo_text.strip()
     if not text or len(text) > 200:
         return
 
-    # Create new todo
     new_todo = Todo(id=next_id, text=text)
     todos_store.append(new_todo)
     next_id += 1
 
-    yield elements(
-        render_todo_item(new_todo, active_filter),
-        "#todo-list",  # Target the todo list container
-        "append",
-    )
+    yield elements(render_todo_item(new_todo, active_filter), "#todo-list", "append")
 
-    # Update only counts, not the full todos array
     completed = sum(1 for t in todos_store if t.completed)
     total = len(todos_store)
     yield signals(
         total_count=total,
         completed_count=completed,
         active_count=total - completed,
-        todo_text="",  # Clear input
+        todo_text="",
     )
 
 
 @rt("/todos/{todo_id}/toggle", methods=["POST"])
 @sse
-def toggle_todo(req, todo_id: str):
-    """Toggle todo completion - surgical update."""
+def toggle_todo(req, todo_id: str, active_filter: Signal = None):
     todo_id = int(todo_id)
-
-    # Find and toggle
     for todo in todos_store:
         if todo.id == todo_id:
             todo.completed = not todo.completed
-
-            # Surgical update - replace just this item
-            # Create a dummy Signal since we're just updating structure, not filter logic
-            yield elements(
-                render_todo_item(todo, Signal("active_filter", "all")), f'[data-todo-id="{todo_id}"]', "outer"
-            )
-
-            # Update only counts
+            yield elements(render_todo_item(todo, active_filter), f'[data-todo-id="{todo_id}"]', "outer")
             completed = sum(1 for t in todos_store if t.completed)
             total = len(todos_store)
             yield signals(
@@ -382,63 +310,35 @@ def toggle_todo(req, todo_id: str):
 @rt("/todos/{todo_id}/edit", methods=["POST"])
 @sse
 def edit_todo(req, todo_id: str, text: str = ""):
-    """Edit todo text."""
     todo_id = int(todo_id)
     text = text.strip()
-
     if not text or len(text) > 200:
         return
-
-    # Find and update
     for todo in todos_store:
         if todo.id == todo_id:
             todo.text = text
-            # No signal updates needed - text change doesn't affect counts
             break
 
 
 @rt("/todos/clear-completed", methods=["DELETE"])
 @sse
 def clear_completed(req):
-    """Clear all completed todos."""
     global todos_store
-
-    # Get IDs to remove for surgical updates
     completed_ids = [t.id for t in todos_store if t.completed]
-
-    # Remove from store
     todos_store = [t for t in todos_store if not t.completed]
-
-    # Surgical removal - remove each completed item
     for todo_id in completed_ids:
         yield elements("", f'[data-todo-id="{todo_id}"]', "outer")
-
-    # Update counts
     total = len(todos_store)
-    yield signals(
-        total_count=total,
-        completed_count=0,  # We just cleared all completed
-        active_count=total,  # All remaining are active
-    )
+    yield signals(total_count=total, completed_count=0, active_count=total)
 
 
 @rt("/todos/{todo_id}", methods=["DELETE"])
 @sse
 def delete_todo(req, todo_id: str):
-    """Delete a single todo - surgical removal."""
     global todos_store
     todo_id = int(todo_id)
-
-    # Check if it was completed before removing
-    any(t.id == todo_id and t.completed for t in todos_store)
-
-    # Remove from store
     todos_store = [t for t in todos_store if t.id != todo_id]
-
-    # Surgical removal
     yield elements("", f'[data-todo-id="{todo_id}"]', "outer")
-
-    # Update counts
     completed = sum(1 for t in todos_store if t.completed)
     total = len(todos_store)
     yield signals(
@@ -447,22 +347,9 @@ def delete_todo(req, todo_id: str):
         active_count=total - completed,
     )
 
-    # Show empty state if no todos left
     if not todos_store:
         yield elements(render_empty_state(), "#todo-list", "inner")
 
 
 if __name__ == "__main__":
-    print("=" * 60)
-    print("🚀 TODO CONQUEROR")
-    print("=" * 60)
-    print("📍 Running on: http://localhost:5001")
-    print("🎨 Design: Bold typography, vibrant gradients, smooth animations")
-    print("⚡ Features:")
-    print("   • Working Datastar patterns")
-    print("   • Bold visual design")
-    print("   • Smooth animations")
-    print("   • Stats dashboard")
-    print("   • Persistent state")
-    print("=" * 60)
     serve(port=5001)


### PR DESCRIPTION
## Summary

- **Starlette 1.0 upgrade**: Replace deprecated `on_startup`/`on_shutdown`/`add_event_handler` with `Lifespan` context manager and `add_lifecycle_handler` API. Add `StarRoute` for deferred endpoint binding. Bump to v0.6.0.
- **Action payload fix**: All kwargs to `post()`, `get()`, etc. are now Datastar action options (`contentType`, `headers`, `payload`, `filterSignals`, etc.). User data is sent automatically via signals — use explicit `payload={}` when you need to send specific values instead.
- **Relay shutdown fix**: Wrap `server.handle_exit` so SSE streams close on first signal, before graceful shutdown waits on open connections (prevents deadlock).
- **Form validation**: Validators (`required`, `email`, `min_length`, etc.) now set HTML constraint attributes (`required`, `aria-required`, `minlength`, `maxlength`, `pattern`). `form_submit` uses `contentType="form"` and gains `reset_on_success` parameter.

## Test plan

- [x] All action helper scenarios verified (bare, payload, options, mixed, all verbs)
- [x] Lifecycle handler tests for startup/shutdown ordering with existing lifespan
- [x] Relay install tests: server exit wrapping, double-wrap guard, unsupported app error
- [x] Form constraint attribute tests for all validators
- [x] Existing test suite passes (failures are pre-existing missing `python-multipart`)