### PR TITLE
Polish Starlette 1.0 branch; fix scroll/canvas listener leaks

### DIFF
--- a/src/starhtml/core.py
+++ b/src/starhtml/core.py
@@ -81,16 +81,23 @@ class Lifespan:
     @asynccontextmanager
     async def __call__(self, app):
         ctx = self.lifespan(app) if self.lifespan else nullcontext()
-        async with ctx:
+        # Forward lifespan state (Starlette 1.0 removed the fallback that
+        # swallowed it; without this req.state.X raises AttributeError).
+        async with ctx as state:
             for f in self.startup:
                 await _run_handler(f, app)
-            yield
+            yield state
             for f in self.shutdown:
                 await _run_handler(f, app)
 
 
 class StarRoute(Route):
-    """Route subclass that wraps endpoints with StarHTML's request processing pipeline."""
+    """Route that runs endpoints through StarHTML's request pipeline.
+
+    Must be bound to a StarHTML app — auto-bound when passed via
+    ``StarHTML(routes=[...])``, ``app.add_route(...)``, or ``app=`` on
+    the constructor.
+    """
 
     def __init__(
         self,
@@ -117,8 +124,12 @@ class StarRoute(Route):
     def _bind(self, app):
         if self._bound:
             return
+        if not isinstance(app, StarHTML):
+            raise TypeError(
+                f"StarRoute({self.path!r}) requires a StarHTML app, got {type(app).__name__}. "
+                "Use StarHTML(routes=[...]) or pass app= to StarRoute."
+            )
         wrapped = app._endp(self._original_endpoint, self._body_wrap or app.body_wrap)
-        # Second super().__init__ is safe — it fully overwrites all Route attrs
         super().__init__(
             self.path,
             wrapped,
@@ -127,6 +138,14 @@ class StarRoute(Route):
             include_in_schema=self.include_in_schema,
         )
         self._bound = True
+
+    async def handle(self, scope, receive, send):
+        if not self._bound:
+            raise RuntimeError(
+                f"StarRoute({self.path!r}) was never bound to a StarHTML app. "
+                "Pass it via StarHTML(routes=[...]) or app.add_route(...)."
+            )
+        await super().handle(scope, receive, send)
 
 
 class StarHTML(Starlette):
@@ -273,7 +292,8 @@ class StarHTML(Starlette):
             self, name: str, static_path: Any = None, hdrs: Any = None, prefix: str | None = None
         ) -> None: ...
         def register_package_static(self, name: str, static_path: Any, prefix: str | None = None) -> None: ...
-        def static_route_exts(self, static_path: str = ".") -> None: ...
+        def static_route_exts(self, prefix: str = "/", static_path: str = ".", exts: str = "static") -> None: ...
+        def static_route(self, ext: str = "", prefix: str = "/", static_path: str = ".") -> None: ...
 
     async def handle_request(
         self,
@@ -356,7 +376,10 @@ def _endp(self: StarHTML, f, body_wrap):
                     bf, skip = b, []
                 if not any(re.fullmatch(r, req.url.path) for r in skip):
                     resp = await _wrap_call(bf, req, _params(bf))
-        req.body_wrap = body_wrap
+        # Beforeware may set req.body_wrap to override the shell for this
+        # request; only fall back to the route/app default if it didn't.
+        if getattr(req, "body_wrap", None) is None:
+            req.body_wrap = body_wrap
         if not resp:
             resp = await _wrap_call(f, req, sig.parameters)
         for a in self.after:

--- a/src/starhtml/core.py
+++ b/src/starhtml/core.py
@@ -5,7 +5,7 @@ import os
 import re
 
 logger = logging.getLogger(__name__)
-from collections.abc import Callable
+from collections.abc import Callable, Collection, Sequence
 from contextlib import asynccontextmanager, nullcontext
 from functools import partialmethod
 from pathlib import Path as PathlibPath
@@ -101,16 +101,16 @@ class StarRoute(Route):
 
     def __init__(
         self,
-        path,
-        endpoint,
+        path: str,
+        endpoint: Callable[..., Any],
         *,
-        app=None,
-        methods=None,
-        name=None,
-        include_in_schema=True,
-        middleware=None,
-        body_wrap=None,
-    ):
+        app: "StarHTML | None" = None,
+        methods: Collection[str] | None = None,
+        name: str | None = None,
+        include_in_schema: bool = True,
+        middleware: Sequence[Middleware] | None = None,
+        body_wrap: Callable[..., Any] | None = None,
+    ) -> None:
         self._original_endpoint = endpoint
         self._body_wrap = body_wrap
         self._bound = False

--- a/src/starhtml/datastar.py
+++ b/src/starhtml/datastar.py
@@ -494,6 +494,32 @@ class Signal(Expr):
             )
         return self.__dict__["_err_cache"]
 
+    def with_initial(self, value: Any) -> "Signal":
+        """Return a new Signal with a replaced initial value (for SSR hydration).
+
+        Raises ValueError on computed signals — their value is derived, not settable.
+        """
+        if self._is_computed:
+            raise ValueError(
+                f"Cannot call with_initial on computed signal {self._name!r}; "
+                "computed signals derive their value from an expression."
+            )
+        return Signal(
+            self._name,
+            initial=value,
+            ifmissing=self._ifmissing,
+            type_=self.type_,
+            namespace=self._namespace,
+            _ref_only=self._ref_only,
+        )
+
+    def persisted(self, persisted_dict: dict[str, Any]) -> "Signal":
+        """Hydrate initial value from a dict keyed by signal name (falls back to
+        the original initial). Typical: ``sig.persisted(req.session.get("state", {}))``
+        so SSR first paint matches server-persisted state.
+        """
+        return self.with_initial(persisted_dict.get(self._name, self._initial))
+
     def validate(self, rule, *args, event="input", **kwargs) -> dict:
         "Validate-on-blur, re-validate-on-input."
         validation = rule(self, *args, **kwargs) if callable(rule) and not isinstance(rule, Expr) else rule
@@ -765,7 +791,38 @@ def scroll_to(
     )
 
 
+# Prefixes preserved unchanged by URL normalization. Shared by action
+# helpers (post/get/...) and realtime history helpers (push/replace_state).
+_ABSOLUTE_URL_PREFIXES = (
+    "/",
+    "@",  # Datastar expression / signal ref
+    "./",
+    "../",
+    "?",  # query-only (preserves current path)
+    "#",
+    "http://",
+    "https://",
+    "ws://",
+    "wss://",
+)
+
+
+def _force_absolute_url(url: str) -> str:
+    """Prepend ``/`` to bare resource paths so fetch/pushState don't resolve
+    them against the current page URL (``'chat/foo'`` from ``/chat/{id}``
+    would become ``/chat/chat/foo`` → 404). Already-absolute, scheme-prefixed,
+    fragment/query, ``./``/``../``, and Datastar ``@expr`` forms pass through.
+
+    Sub-mount caveat: assumes root mount. Under a mount prefix, use
+    ``req.url_for(name)`` (root_path-aware) or hardcode the prefix.
+    """
+    if url and not url.startswith(_ABSOLUTE_URL_PREFIXES):
+        return "/" + url
+    return url
+
+
 def _action(verb: str, url: str, **kwargs) -> _JSRaw:
+    url = _force_absolute_url(url)
     if not kwargs:
         return _JSRaw(f"@{verb}('{url}')")
     opts = ", ".join(f"{k}: {to_js_value(v)}" for k, v in kwargs.items())
@@ -801,8 +858,7 @@ def emit(event_name: str, **detail) -> _JSRaw:
     return _JSRaw(f"el.dispatchEvent(new CustomEvent('{event_name}', {{bubbles: true{detail_js}}}))")
 
 
-# Datastar plugins using "on-*" naming (hyphen syntax, not colon like DOM events)
-_ON_PLUGINS: set[str] = {"interval", "intersect", "signal_patch"}
+_ON_PLUGINS: set[str] = {"interval", "intersect", "signal_patch", "signal_patch_filter"}
 
 
 def register_on_plugin(name: str) -> None:

--- a/src/starhtml/forms.py
+++ b/src/starhtml/forms.py
@@ -171,7 +171,7 @@ def form_submit(
         attrs["data_signals"] = auto_created
     if reset_on_success and submitted:
         attrs["data_on_signal_patch"] = submitted & form_reset(*signals)
-        attrs["data-on-signal-patch-filter"] = f"{{include: /^{submitted._id}$/}}"
+        attrs["data_on_signal_patch_filter"] = f"{{include: /^{submitted._id}$/}}"
     return FormAttrs(attrs, submitting=submitting, submitted=submitted, error=error)
 
 

--- a/src/starhtml/realtime.py
+++ b/src/starhtml/realtime.py
@@ -4,6 +4,7 @@ import asyncio
 import contextvars
 import inspect
 import itertools
+import json
 import logging
 import re
 import time
@@ -21,6 +22,7 @@ from starlette.responses import StreamingResponse
 from starlette.routing import WebSocketRoute
 from starlette.websockets import WebSocket
 
+from .datastar import _force_absolute_url
 from .html import fh_cfg
 from .utils import _params, empty
 
@@ -33,6 +35,9 @@ __all__ = [
     "signals",
     "elements",
     "execute_script",
+    "push_state",
+    "replace_state",
+    "redirect",
     "SSE_HEADERS",
     "RETRY_DURATION",
     "EventStream",
@@ -407,6 +412,40 @@ def execute_script(
     script_element = Script(script_content, **script_attrs)
 
     return elements(script_element, selector="body", mode="append")
+
+
+def _history_update(method: str, url: str) -> tuple[str, tuple]:
+    safe = json.dumps(_force_absolute_url(url))
+    return execute_script(f"if(location.pathname!=={safe})history.{method}State({{}},'',{safe})")
+
+
+def push_state(url: str) -> tuple[str, tuple]:
+    """SSE item: push a new browser history entry without a page reload.
+
+    Idempotent — skips when ``location.pathname`` already matches. Use
+    ``replace_state`` when the update shouldn't add a back-button entry.
+    """
+    return _history_update("push", url)
+
+
+def replace_state(url: str) -> tuple[str, tuple]:
+    """SSE item: replace the current browser history entry.
+
+    Idempotent — skips when ``location.pathname`` already matches. Use
+    ``push_state`` when the update should add a back-button entry.
+    """
+    return _history_update("replace", url)
+
+
+def redirect(url: str) -> tuple[str, tuple]:
+    """SSE item: full-page navigation via ``window.location``.
+
+    ``setTimeout(0)`` defers past the current tick so in-flight Datastar
+    patches apply before teardown. Use ``push_state`` / ``replace_state``
+    for URL updates without a page reload.
+    """
+    safe = json.dumps(_force_absolute_url(url))
+    return execute_script(f"setTimeout(()=>window.location={safe})")
 
 
 def sse_message(elm, event="message"):

--- a/tests/unit/test_datastar_new_api.py
+++ b/tests/unit/test_datastar_new_api.py
@@ -245,3 +245,220 @@ class TestIntegration:
         assert "data-style-opacity" in html
         assert "data-style-transform" in html
         assert "`scale(${$scale})`" in html
+
+
+class TestActionUrlNormalization:
+    """``post()`` / ``get()`` / ``put()`` / ``delete()`` / ``patch()`` should
+    force a leading slash on bare resource paths so that the browser's
+    ``fetch()`` resolves the URL absolutely instead of relative to the
+    current page URL.
+
+    Background: under per-resource URL routing (e.g. ``/chat/{uuid}``),
+    a Datastar action like ``post('chat/foo')`` would resolve to
+    ``/chat/chat/foo`` from any sub-resource page — silently broken in
+    a way that doesn't surface in tests or on landing pages. Forcing the
+    leading slash at the helper level prevents the entire bug class.
+    """
+
+    def test_post_bare_resource_gets_leading_slash(self):
+        # 'chat/foo' must become '/chat/foo' so it's an absolute URL.
+        assert str(post("chat/foo")) == "@post('/chat/foo')"
+
+    def test_get_bare_resource_gets_leading_slash(self):
+        assert str(get("api/users")) == "@get('/api/users')"
+
+    def test_put_bare_resource_gets_leading_slash(self):
+        assert str(put("items/42")) == "@put('/items/42')"
+
+    def test_delete_bare_resource_gets_leading_slash(self):
+        assert str(delete("things/x")) == "@delete('/things/x')"
+
+    def test_patch_bare_resource_gets_leading_slash(self):
+        assert str(patch("things/x")) == "@patch('/things/x')"
+
+    def test_already_absolute_path_unchanged(self):
+        assert str(post("/chat/foo")) == "@post('/chat/foo')"
+        assert str(get("/api/users")) == "@get('/api/users')"
+
+    def test_full_https_url_unchanged(self):
+        assert str(post("https://api.example.com/v1/foo")) == "@post('https://api.example.com/v1/foo')"
+
+    def test_full_http_url_unchanged(self):
+        assert str(post("http://localhost:8000/foo")) == "@post('http://localhost:8000/foo')"
+
+    def test_websocket_url_unchanged(self):
+        assert str(get("ws://localhost/socket")) == "@get('ws://localhost/socket')"
+        assert str(get("wss://api.example.com/socket")) == "@get('wss://api.example.com/socket')"
+
+    def test_explicit_relative_dot_unchanged(self):
+        # Author explicitly used './' — preserve their intent.
+        assert str(post("./relative")) == "@post('./relative')"
+
+    def test_explicit_parent_relative_unchanged(self):
+        assert str(post("../parent")) == "@post('../parent')"
+
+    def test_query_only_unchanged(self):
+        # Query-only refresh of the current URL — preserve.
+        assert str(get("?refresh=1")) == "@get('?refresh=1')"
+
+    def test_fragment_only_unchanged(self):
+        assert str(get("#anchor")) == "@get('#anchor')"
+
+    def test_datastar_expression_prefix_unchanged(self):
+        # An '@'-prefixed value would be a Datastar expression, not a URL.
+        # Defensive: preserve unchanged so the user can debug their typo.
+        assert str(post("@signal")) == "@post('@signal')"
+
+    def test_normalization_preserves_kwargs(self):
+        # The kwargs path renders an options object after the URL —
+        # normalization must apply BEFORE the kwargs render so the
+        # options object is unaffected.
+        result = str(post("chat/ui-state", contentType="json"))
+        assert result.startswith("@post('/chat/ui-state'")
+        assert "contentType:" in result
+
+    def test_fstring_with_dynamic_segment(self):
+        # The most common pattern that bit zacks: f-string with a UUID.
+        thread_id = "abc-123"
+        assert str(post(f"chat/select-thread/{thread_id}")) == "@post('/chat/select-thread/abc-123')"
+
+
+class TestForceAbsoluteUrlHelper:
+    """The shared ``_force_absolute_url`` helper that powers both the
+    ``post``/``get``/``put``/``delete``/``patch`` action helpers and the
+    realtime ``push_state``/``replace_state`` history helpers. Direct
+    helper tests so coverage is independent of the call-site flow.
+    """
+
+    def test_bare_path_gets_leading_slash(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("foo") == "/foo"
+        assert _force_absolute_url("api/v1/users") == "/api/v1/users"
+
+    def test_already_absolute_unchanged(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("/foo") == "/foo"
+        assert _force_absolute_url("//example.com/foo") == "//example.com/foo"  # protocol-relative
+
+    def test_explicit_relative_unchanged(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("./foo") == "./foo"
+        assert _force_absolute_url("../foo") == "../foo"
+
+    def test_full_urls_unchanged(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("http://x.test/foo") == "http://x.test/foo"
+        assert _force_absolute_url("https://x.test/foo") == "https://x.test/foo"
+        assert _force_absolute_url("ws://x.test/socket") == "ws://x.test/socket"
+        assert _force_absolute_url("wss://x.test/socket") == "wss://x.test/socket"
+
+    def test_query_and_fragment_only_unchanged(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("?refresh=1") == "?refresh=1"
+        assert _force_absolute_url("#anchor") == "#anchor"
+
+    def test_datastar_expression_unchanged(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("@signal") == "@signal"
+
+    def test_empty_string_unchanged(self):
+        from starhtml.datastar import _force_absolute_url
+
+        assert _force_absolute_url("") == ""
+
+
+class TestStateHelpersNormalization:
+    """``push_state`` and ``replace_state`` should apply the same URL
+    normalization as the action helpers, so a bare resource path doesn't
+    silently push the wrong URL under per-resource routing.
+    """
+
+    def test_push_state_normalizes_bare_url(self):
+        from starhtml import push_state
+
+        result = push_state("dashboard")
+        # ('elements', (script_element, selector, mode, ...))
+        script_html = str(result[1][0])
+        assert '"/dashboard"' in script_html
+        # Plain (non-slashed) form should not appear in the JSON-encoded URL.
+        assert '"dashboard"' not in script_html
+        assert "history.pushState" in script_html
+
+    def test_push_state_preserves_absolute_url(self):
+        from starhtml import push_state
+
+        result = push_state("/chat/abc")
+        script_html = str(result[1][0])
+        assert '"/chat/abc"' in script_html
+
+    def test_push_state_fstring_uuid(self):
+        from starhtml import push_state
+
+        thread_id = "abc-123"
+        result = push_state(f"chat/{thread_id}")
+        script_html = str(result[1][0])
+        assert '"/chat/abc-123"' in script_html
+
+    def test_replace_state_normalizes_bare_url(self):
+        from starhtml import replace_state
+
+        result = replace_state("dashboard")
+        script_html = str(result[1][0])
+        assert '"/dashboard"' in script_html
+        assert "history.replaceState" in script_html
+
+    def test_replace_state_preserves_full_url(self):
+        from starhtml import replace_state
+
+        # Full URLs (e.g., to a different host) should not be normalized.
+        result = replace_state("https://other.example/foo")
+        script_html = str(result[1][0])
+        assert '"https://other.example/foo"' in script_html
+
+
+class TestRedirectHelper:
+    """``redirect()`` should perform full-page navigation via
+    ``window.location`` and apply the same URL normalization as the
+    history helpers, so a bare URL doesn't navigate to the wrong place
+    under per-resource routing.
+    """
+
+    def test_redirect_normalizes_bare_url(self):
+        from starhtml import redirect
+
+        result = redirect("login")
+        script_html = str(result[1][0])
+        assert '"/login"' in script_html
+        assert "window.location" in script_html
+        assert "setTimeout" in script_html  # deferred past in-flight patches
+
+    def test_redirect_preserves_absolute_path(self):
+        from starhtml import redirect
+
+        result = redirect("/dashboard")
+        script_html = str(result[1][0])
+        assert '"/dashboard"' in script_html
+
+    def test_redirect_preserves_full_https_url(self):
+        from starhtml import redirect
+
+        # The Stripe-checkout pattern: redirect to a fully-qualified
+        # external URL should NOT be normalized.
+        url = "https://checkout.stripe.com/c/pay/cs_test_abc123"
+        result = redirect(url)
+        script_html = str(result[1][0])
+        assert f'"{url}"' in script_html
+
+    def test_redirect_fstring_with_dynamic_segment(self):
+        from starhtml import redirect
+
+        thread_id = "abc-123"
+        result = redirect(f"chat/{thread_id}")
+        script_html = str(result[1][0])
+        assert '"/chat/abc-123"' in script_html

--- a/tests/unit/test_forms.py
+++ b/tests/unit/test_forms.py
@@ -538,13 +538,13 @@ class TestFormSubmit:
         [sig] = self._make_validated_signals("name")
         result = form_submit("test", sig, name="t")
         assert "data_on_signal_patch" not in result
-        assert "data-on-signal-patch-filter" not in result
+        assert "data_on_signal_patch_filter" not in result
 
     def test_reset_on_success_adds_signal_patch_handler(self):
         [sig] = self._make_validated_signals("name")
         result = form_submit("test", sig, name="t", reset_on_success=True)
         assert "data_on_signal_patch" in result
-        assert result["data-on-signal-patch-filter"] == "{include: /^t_submitted$/}"
+        assert result["data_on_signal_patch_filter"] == "{include: /^t_submitted$/}"
 
     def test_reset_on_success_guards_on_submitted(self):
         [sig] = self._make_validated_signals("name")
@@ -574,7 +574,7 @@ class TestFormSubmit:
         my_sub = Signal("sub", False)
         result = form_submit("test", sig, submitting=my_sub, reset_on_success=True)
         assert "data_on_signal_patch" not in result
-        assert "data-on-signal-patch-filter" not in result
+        assert "data_on_signal_patch_filter" not in result
 
 
 # ============================================================================

--- a/tests/unit/test_signal_with_initial_and_persisted.py
+++ b/tests/unit/test_signal_with_initial_and_persisted.py
@@ -1,0 +1,433 @@
+"""Tests for Signal.with_initial() and Signal.persisted() methods."""
+
+import pytest
+
+from starhtml.datastar import Signal, js
+
+
+class TestWithInitial:
+    """Test Signal.with_initial() method for SSR hydration."""
+
+    def test_with_initial_replaces_initial_value(self):
+        """Test that with_initial replaces the initial value."""
+        original = Signal("count", 0)
+        updated = original.with_initial(42)
+
+        assert original._initial == 0
+        assert updated._initial == 42
+
+    def test_with_initial_preserves_name(self):
+        """Test that name is preserved across with_initial."""
+        original = Signal("user_email", "default@example.com")
+        updated = original.with_initial("new@example.com")
+
+        assert original._name == "user_email"
+        assert updated._name == "user_email"
+        assert updated._name == original._name
+
+    def test_with_initial_preserves_type(self):
+        """Test that inferred or explicit type is preserved."""
+        # String type inference
+        original_str = Signal("name", "Alice")
+        updated_str = original_str.with_initial("Bob")
+        assert updated_str.type_ is str
+
+        # Int type inference
+        original_int = Signal("count", 10)
+        updated_int = original_int.with_initial(20)
+        assert updated_int.type_ is int
+
+        # Bool type inference
+        original_bool = Signal("active", True)
+        updated_bool = original_bool.with_initial(False)
+        assert updated_bool.type_ is bool
+
+        # Explicit type specification
+        original_explicit = Signal("value", 0, type_=float)
+        updated_explicit = original_explicit.with_initial(3.14)
+        assert updated_explicit.type_ is float
+
+    def test_with_initial_preserves_namespace(self):
+        """Test that namespace and derived _id are preserved."""
+        original = Signal("dark_mode", False, namespace="theme")
+        updated = original.with_initial(True)
+
+        assert original._namespace == "theme"
+        assert updated._namespace == "theme"
+        assert original._id == "theme_dark_mode"
+        assert updated._id == "theme_dark_mode"
+        assert original._id == updated._id
+
+    def test_with_initial_preserves_ifmissing_true(self):
+        """Test that ifmissing=True is preserved."""
+        original = Signal("setting", 100, ifmissing=True)
+        updated = original.with_initial(200)
+
+        assert original._ifmissing is True
+        assert updated._ifmissing is True
+        # Verify it affects to_dict behavior
+        assert original.to_dict() == {}
+        assert updated.to_dict() == {}
+
+    def test_with_initial_preserves_ifmissing_false(self):
+        """Test that ifmissing=False is preserved."""
+        original = Signal("config", {"key": "value"}, ifmissing=False)
+        updated = original.with_initial({"key": "new_value"})
+
+        assert original._ifmissing is False
+        assert updated._ifmissing is False
+        # Verify it affects to_dict behavior
+        assert original.to_dict() == {"config": {"key": "value"}}
+        assert updated.to_dict() == {"config": {"key": "new_value"}}
+
+    def test_with_initial_preserves_ref_only_true(self):
+        """Test that _ref_only=True is preserved."""
+        original = Signal("error_msg", "", _ref_only=True)
+        updated = original.with_initial("New error")
+
+        assert original._ref_only is True
+        assert updated._ref_only is True
+        # Verify get_signal_attr respects _ref_only
+        assert original.get_signal_attr() is None
+        assert updated.get_signal_attr() is None
+
+    def test_with_initial_preserves_ref_only_false(self):
+        """Test that _ref_only=False is preserved."""
+        original = Signal("count", 5, _ref_only=False)
+        updated = original.with_initial(10)
+
+        assert original._ref_only is False
+        assert updated._ref_only is False
+        # Verify get_signal_attr returns attribute
+        assert original.get_signal_attr() is not None
+        assert updated.get_signal_attr() is not None
+
+    def test_with_initial_on_computed_raises_valueerror(self):
+        """Test that with_initial raises ValueError on computed signals."""
+        base = Signal("base", 5)
+        computed = Signal("doubled", base * 2)
+
+        assert computed._is_computed is True
+
+        with pytest.raises(ValueError) as exc_info:
+            computed.with_initial(20)
+
+        assert "Cannot call with_initial on computed signal" in str(exc_info.value)
+        assert "doubled" in str(exc_info.value)
+        assert "derive their value from an expression" in str(exc_info.value)
+
+    def test_with_initial_on_js_computed_raises_valueerror(self):
+        """Test that with_initial raises ValueError on js() expressions."""
+        computed = Signal("user_name", js("$user.name || 'Anonymous'"))
+
+        assert computed._is_computed is True
+
+        with pytest.raises(ValueError) as exc_info:
+            computed.with_initial("John")
+
+        assert "Cannot call with_initial on computed signal" in str(exc_info.value)
+
+    def test_with_initial_returns_new_instance(self):
+        """Test that with_initial returns a distinct instance."""
+        original = Signal("count", 0)
+        updated = original.with_initial(42)
+
+        assert original is not updated
+        assert isinstance(updated, Signal)
+
+    def test_with_initial_resets_constraint_attrs(self):
+        """Test that validation/constraint attributes start clean on new instance."""
+        original = Signal("email", "test@example.com")
+        # Simulate constraint attrs being set (as validate() does)
+        original._constraint_attrs = {"some_key": "some_value"}
+
+        updated = original.with_initial("new@example.com")
+
+        # New instance starts with empty constraint attrs
+        assert updated._constraint_attrs == {}
+        # Original is unchanged
+        assert original._constraint_attrs == {"some_key": "some_value"}
+
+    def test_with_initial_new_value_rendered_in_signal_attr(self):
+        """Test that new initial value appears in get_signal_attr() output."""
+        original = Signal("theme", "light", ifmissing=True)
+        updated = original.with_initial("dark")
+
+        # Check original
+        orig_attr_name, orig_attr_val = original.get_signal_attr()
+        assert orig_attr_name == "data-signals:theme__ifmissing"
+        assert orig_attr_val == "light"
+
+        # Check updated
+        upd_attr_name, upd_attr_val = updated.get_signal_attr()
+        assert upd_attr_name == "data-signals:theme__ifmissing"
+        assert upd_attr_val == "dark"
+
+    def test_with_initial_none_value(self):
+        """Test with_initial with None as new value."""
+        original = Signal("optional", "something")
+        updated = original.with_initial(None)
+
+        assert updated._initial is None
+        # None initial values don't produce signal attrs
+        assert updated.get_signal_attr() is None
+
+    def test_with_initial_complex_types(self):
+        """Test with_initial with lists and dicts."""
+        original_list = Signal("items", [1, 2, 3])
+        updated_list = original_list.with_initial([4, 5, 6])
+        assert updated_list._initial == [4, 5, 6]
+
+        original_dict = Signal("config", {"a": 1})
+        updated_dict = original_dict.with_initial({"b": 2})
+        assert updated_dict._initial == {"b": 2}
+
+    def test_with_initial_js_string_literal(self):
+        """Test with_initial with string that looks like JS but is treated as literal."""
+        original = Signal("code", "const x = 1;")
+        updated = original.with_initial("const y = 2;")
+
+        assert updated._initial == "const y = 2;"
+        assert updated._is_computed is False
+
+
+class TestPersisted:
+    """Test Signal.persisted() method for dict-based hydration."""
+
+    def test_persisted_hydrates_from_dict(self):
+        """Test that persisted looks up signal name in dict and uses that value."""
+        signal = Signal("user_id", 0)
+        persisted_dict = {"user_id": 123}
+
+        hydrated = signal.persisted(persisted_dict)
+
+        assert signal._initial == 0
+        assert hydrated._initial == 123
+
+    def test_persisted_fallback_to_original(self):
+        """Test that missing key in dict uses original initial value."""
+        signal = Signal("username", "default_user")
+        persisted_dict = {"other_key": "other_value"}
+
+        hydrated = signal.persisted(persisted_dict)
+
+        assert hydrated._initial == "default_user"
+
+    def test_persisted_with_empty_dict(self):
+        """Test that empty dict results in original initial value."""
+        signal = Signal("count", 42)
+        hydrated = signal.persisted({})
+
+        assert hydrated._initial == 42
+
+    def test_persisted_none_in_dict_is_used(self):
+        """Test that None value in dict is used (not treated as missing)."""
+        signal = Signal("optional", "default")
+        persisted_dict = {"optional": None}
+
+        hydrated = signal.persisted(persisted_dict)
+
+        assert hydrated._initial is None
+
+    def test_persisted_zero_value_in_dict_is_used(self):
+        """Test that falsy values (0, False) in dict are used."""
+        signal_int = Signal("count", 10)
+        persisted_dict_int = {"count": 0}
+        hydrated_int = signal_int.persisted(persisted_dict_int)
+        assert hydrated_int._initial == 0
+
+        signal_bool = Signal("active", True)
+        persisted_dict_bool = {"active": False}
+        hydrated_bool = signal_bool.persisted(persisted_dict_bool)
+        assert hydrated_bool._initial is False
+
+    def test_persisted_preserves_all_other_fields(self):
+        """Test that persisted preserves name, type, namespace, ifmissing, _ref_only."""
+        original = Signal("setting", "original", ifmissing=False, type_=str, namespace="app", _ref_only=True)
+        persisted_dict = {"setting": "hydrated"}
+
+        hydrated = original.persisted(persisted_dict)
+
+        # Check all fields
+        assert hydrated._name == "setting"
+        assert hydrated.type_ is str
+        assert hydrated._namespace == "app"
+        assert hydrated._ifmissing is False
+        assert hydrated._ref_only is True
+        assert hydrated._initial == "hydrated"
+        assert hydrated._id == "app_setting"
+
+    def test_persisted_on_computed_raises_valueerror(self):
+        """Test that persisted raises ValueError on computed signals (via with_initial)."""
+        base = Signal("count", 5)
+        computed = Signal("doubled", base * 2)
+        persisted_dict = {"doubled": 10}
+
+        with pytest.raises(ValueError) as exc_info:
+            computed.persisted(persisted_dict)
+
+        assert "Cannot call with_initial on computed signal" in str(exc_info.value)
+
+    def test_persisted_with_namespaced_signal(self):
+        """Test that persisted uses _name (unprefixed) as dict key, not _id."""
+        # Namespaced signals have _id = "namespace_name"
+        # but persisted() should lookup by _name only
+        signal = Signal("left_open", False, namespace="drawer")
+        assert signal._name == "left_open"
+        assert signal._id == "drawer_left_open"
+
+        # Dict keyed by _name, not _id
+        persisted_dict = {"left_open": True}
+
+        hydrated = signal.persisted(persisted_dict)
+
+        assert hydrated._initial is True
+        assert hydrated._namespace == "drawer"
+        assert hydrated._id == "drawer_left_open"
+
+    def test_persisted_with_namespaced_signal_missing_uses_original(self):
+        """Test that missing namespaced key uses original initial."""
+        signal = Signal("setting", "default", namespace="app")
+
+        # Dict doesn't have the key
+        persisted_dict = {}
+
+        hydrated = signal.persisted(persisted_dict)
+
+        assert hydrated._initial == "default"
+
+    def test_persisted_returns_new_instance(self):
+        """Test that persisted returns a new Signal instance."""
+        original = Signal("count", 0)
+        hydrated = original.persisted({"count": 10})
+
+        assert original is not hydrated
+        assert isinstance(hydrated, Signal)
+
+    def test_persisted_with_complex_types(self):
+        """Test persisted with lists and dicts."""
+        original_list = Signal("items", [])
+        hydrated_list = original_list.persisted({"items": [1, 2, 3]})
+        assert hydrated_list._initial == [1, 2, 3]
+
+        original_dict = Signal("config", {})
+        hydrated_dict = original_dict.persisted({"config": {"theme": "dark"}})
+        assert hydrated_dict._initial == {"theme": "dark"}
+
+    def test_persisted_is_sugar_over_with_initial(self):
+        """Test that persisted(dict) is equivalent to with_initial(dict.get(...))."""
+        signal = Signal("value", 100)
+        persisted_dict = {"value": 200}
+
+        # Using persisted
+        via_persisted = signal.persisted(persisted_dict)
+
+        # Using with_initial directly
+        via_with_initial = signal.with_initial(persisted_dict.get("value", signal._initial))
+
+        assert via_persisted._initial == via_with_initial._initial
+        assert via_persisted._name == via_with_initial._name
+        assert via_persisted._namespace == via_with_initial._namespace
+
+    def test_persisted_multiple_signals_from_session(self):
+        """Test real-world scenario: hydrating multiple signals from session dict."""
+        # Simulating a drawer state persisted in session
+        session_state = {
+            "left_open": True,
+            "right_open": False,
+            "width": 250,
+        }
+
+        left = Signal("left_open", False, namespace="drawer")
+        right = Signal("right_open", False, namespace="drawer")
+        width = Signal("width", 200, namespace="drawer")
+
+        # Hydrate all from session
+        left_hydrated = left.persisted(session_state)
+        right_hydrated = right.persisted(session_state)
+        width_hydrated = width.persisted(session_state)
+
+        assert left_hydrated._initial is True
+        assert right_hydrated._initial is False
+        assert width_hydrated._initial == 250
+
+    def test_persisted_extra_keys_in_dict_ignored(self):
+        """Test that extra keys in dict don't affect signal hydration."""
+        signal = Signal("user_id", 0)
+        persisted_dict = {
+            "user_id": 42,
+            "extra_key": "extra_value",
+            "another_key": 999,
+        }
+
+        hydrated = signal.persisted(persisted_dict)
+
+        assert hydrated._initial == 42
+
+
+class TestWithInitialAndPersistedIntegration:
+    """Integration tests combining both methods."""
+
+    def test_with_initial_then_persisted(self):
+        """Test chaining with_initial followed by persisted."""
+        original = Signal("count", 0)
+
+        # First modify initial
+        updated = original.with_initial(10)
+
+        # Then hydrate from dict
+        persisted_dict = {"count": 42}
+        hydrated = updated.persisted(persisted_dict)
+
+        assert original._initial == 0
+        assert updated._initial == 10
+        assert hydrated._initial == 42
+
+    def test_persisted_then_with_initial(self):
+        """Test chaining persisted followed by with_initial."""
+        original = Signal("value", 0)
+        persisted_dict = {"value": 100}
+
+        # First hydrate from dict
+        hydrated = original.persisted(persisted_dict)
+        assert hydrated._initial == 100
+
+        # Then further modify
+        modified = hydrated.with_initial(200)
+        assert modified._initial == 200
+
+    def test_multiple_persisted_calls_independent(self):
+        """Test that calling persisted multiple times is independent."""
+        signal = Signal("state", "initial")
+
+        dict1 = {"state": "from_dict1"}
+        hydrated1 = signal.persisted(dict1)
+
+        dict2 = {"state": "from_dict2"}
+        hydrated2 = signal.persisted(dict2)
+
+        # Both should be independent
+        assert hydrated1._initial == "from_dict1"
+        assert hydrated2._initial == "from_dict2"
+        assert signal._initial == "initial"
+
+    def test_validation_workflow_with_persisted(self):
+        """Test real-world validation workflow with persisted hydration."""
+        # Original signal with no initial (to validate against)
+        email = Signal("email", "")
+
+        # User submits form; we get their current value from request
+        form_data = {"email": "user@example.com"}
+        hydrated = email.persisted(form_data)
+
+        # Then we apply validation rules (which sets _constraint_attrs)
+        hydrated.validate(lambda sig: sig.length > 0, event="input")
+
+        # The new instance's constraint attrs should now be set
+        assert len(hydrated._constraint_attrs) > 0
+        # But the original should be unaffected
+        assert len(email._constraint_attrs) == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_star_route.py
+++ b/tests/unit/test_star_route.py
@@ -196,3 +196,100 @@ class TestStarRouteDeferredBinding:
         resp = client.get("/dynamic")
         assert resp.status_code == 200
         assert "added" in resp.text
+
+
+class TestStarRouteGuards:
+    """Fail-fast errors when StarRoute is misused (wrong app type / unbound)."""
+
+    def test_bind_rejects_non_starhtml_app(self):
+        """StarRoute(..., app=plain_starlette) raises TypeError with actionable guidance."""
+        import pytest
+        from starlette.applications import Starlette
+
+        plain_app = Starlette()
+
+        with pytest.raises(TypeError) as excinfo:
+            StarRoute("/oops", lambda: "x", app=plain_app)
+
+        msg = str(excinfo.value)
+        assert "StarRoute" in msg
+        assert "StarHTML" in msg
+        assert "StarHTML(routes=" in msg
+
+    def test_unbound_starroute_raises_clear_error_at_request_time(self):
+        """A StarRoute that ends up in a plain Starlette app (never bound) raises a clear RuntimeError."""
+        import pytest
+        from starlette.applications import Starlette
+
+        def handler():
+            return "unreachable"
+
+        unbound = StarRoute("/fragment", handler)
+        assert unbound._bound is False
+
+        plain_app = Starlette(routes=[unbound])
+        client = TestClient(plain_app)
+
+        with pytest.raises(RuntimeError) as excinfo:
+            client.get("/fragment")
+
+        msg = str(excinfo.value)
+        assert "StarRoute" in msg
+        assert "never bound" in msg
+        assert "StarHTML(routes=" in msg
+        assert "add_route" in msg
+
+
+class TestRuntimeBodyWrap:
+    """Beforeware can override body_wrap per request (htmx fragments, embed views, etc.)."""
+
+    def test_beforeware_body_wrap_override_is_respected(self):
+        """A beforeware that sets ``req.body_wrap`` wins over the app-level default."""
+
+        def app_wrap(content):
+            return Div(content, cls="app-shell")
+
+        def fragment_wrap(content):
+            # Bare passthrough for htmx/iframe/embed fragment requests
+            return content
+
+        def maybe_fragment(req):
+            if req.headers.get("x-fragment") == "1":
+                req.body_wrap = fragment_wrap
+
+        app = StarHTML(body_wrap=app_wrap, before=[maybe_fragment])
+
+        @app.route("/page")
+        def page():
+            return Div("hello", id="content")
+
+        client = TestClient(app)
+
+        # No header → app-level shell kicks in
+        full = client.get("/page")
+        assert full.status_code == 200
+        assert 'class="app-shell"' in full.text
+
+        # With header → beforeware override wins
+        frag = client.get("/page", headers={"x-fragment": "1"})
+        assert frag.status_code == 200
+        assert 'class="app-shell"' not in frag.text
+        assert 'id="content"' in frag.text
+
+    def test_app_body_wrap_still_applies_when_no_override(self):
+        """Default path unchanged: app-level body_wrap applies when beforeware doesn't touch it."""
+
+        def shell(content):
+            return Div(content, cls="outer-shell")
+
+        app = StarHTML(body_wrap=shell)
+
+        @app.route("/default")
+        def default_page():
+            return Div("hi", id="inner")
+
+        client = TestClient(app)
+        resp = client.get("/default")
+        assert resp.status_code == 200
+        assert 'class="outer-shell"' in resp.text
+        assert 'id="inner"' in resp.text

--- a/typescript/plugins/canvas.ts
+++ b/typescript/plugins/canvas.ts
@@ -114,6 +114,9 @@ class CanvasController {
   }
 
   private registerInGlobalRegistry() {
+    // Replace any prior controller on the same signal so re-mounts (hot reload,
+    // dynamic re-apply) don't leak document-level listeners from the old one.
+    controllerRegistry[this.config.signal]?.destroy();
     controllerRegistry[this.config.signal] = this;
   }
   public setContext(ctx: AttributeContext) {

--- a/typescript/plugins/scroll.ts
+++ b/typescript/plugins/scroll.ts
@@ -18,7 +18,7 @@ const SCROLL_ARG_NAMES = [
   "scroll_progress",
 ] as const;
 
-let globalScrollInitialized = false;
+let globalRefCount = 0;
 let globalScrollManager: (() => void) | null = null;
 
 function calculateVisiblePercent(rect: DOMRect, viewportHeight: number): number {
@@ -48,9 +48,8 @@ const scrollAttributePlugin: AttributePlugin = {
   apply(ctx: AttributeContext): OnRemovalFn | void {
     const { el, value, mods, rx } = ctx;
 
-    const shouldManageGlobal = !globalScrollInitialized;
-    if (shouldManageGlobal) {
-      globalScrollInitialized = true;
+    globalRefCount++;
+    if (globalRefCount === 1) {
       mergePatch({
         scroll_x: window.scrollX || 0,
         scroll_y: window.scrollY || 0,
@@ -174,22 +173,21 @@ const scrollAttributePlugin: AttributePlugin = {
     const handleElementScroll = () => throttledElementUpdate();
     window.addEventListener("scroll", handleElementScroll, { passive: true });
 
-    let elementScrollCleanup: (() => void) | null = null;
-    if (el.scrollHeight > el.clientHeight) {
-      const handleInternalScroll = () => throttledElementUpdate();
-      el.addEventListener("scroll", handleInternalScroll, { passive: true });
-      elementScrollCleanup = () => el.removeEventListener("scroll", handleInternalScroll);
-    }
+    // Attach unconditionally: a mount-time scrollable check misses elements
+    // that become scrollable later (streaming chat, infinite lists).
+    const handleInternalScroll = () => throttledElementUpdate();
+    el.addEventListener("scroll", handleInternalScroll, { passive: true });
+    const elementScrollCleanup = () => el.removeEventListener("scroll", handleInternalScroll);
 
     return () => {
       window.removeEventListener("scroll", handleElementScroll);
-      elementScrollCleanup?.();
+      elementScrollCleanup();
       smoothScroll?.cleanup();
 
-      if (shouldManageGlobal && globalScrollManager) {
+      globalRefCount--;
+      if (globalRefCount === 0 && globalScrollManager) {
         globalScrollManager();
         globalScrollManager = null;
-        globalScrollInitialized = false;
       }
     };
   },

--- a/uv.lock
+++ b/uv.lock
@@ -1098,7 +1098,7 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.5.24"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- Add `Signal.with_initial()` / `Signal.persisted()` for SSR hydration from request-scoped state (+ full test coverage)
- Add URL helpers: `push_state` / `replace_state` / `redirect` SSE items, plus shared `_force_absolute_url` used by action helpers and history helpers
- Wire `signal_patch_filter` as a first-class plugin modifier so forms can scope signal-patch handlers
- Fix two pre-existing plugin lifecycle bugs:
  - **scroll.ts:** global listener was torn down by the first-unmounted consumer, breaking N>1 consumers; now uses a module-level refcount
  - **canvas.ts:** re-registering a controller on the same signal leaked the prior controller's document-level listeners; now destroys the prior controller on re-register (hot-reload safe)