### PR TITLE
[PR] fix(position): default elementResize to true for popovers

### DIFF
--- a/typescript/plugins/position.ts
+++ b/typescript/plugins/position.ts
@@ -428,7 +428,7 @@ const positionAttributePlugin: AttributePlugin = {
       cleanup = autoUpdate(target, el, updatePosition, {
         ancestorScroll: true,
         ancestorResize: true,
-        elementResize: au.elementResize ?? false,
+        elementResize: au.elementResize ?? isPopover,
         layoutShift: au.layoutShift ?? false,
       });
     };


### PR DESCRIPTION
**Related Issue**
#83 

**Proposed Changes**
In `typescript/plugins/position.ts`, the `start()` function calls `autoUpdate` with `elementResize: false` hardcoded as the default. This means Floating UI's ResizeObserver is never attached to the floating element for popovers. When a combobox dropdown flips to top placement and the user filters items (causing the popup height to shrink), the position is never recalculated and the popup floats at stale coordinates detached from its trigger.

The fix changes the default from `false` to `isPopover` (already computed in the same closure). Non-popover positioned elements are unaffected. The workaround `window.__starhtml_position_config = {autoUpdate: {elementResize: true}}` remains valid for anyone who needs to override the behaviour in either direction.

Changed line in `typescript/plugins/position.ts` (~line 325):

```
// before
elementResize: au.elementResize ?? false,

// after
elementResize: au.elementResize ?? isPopover,
```

**Types of changes**
- [x] Bug fix (non-breaking change which fixes an issue)

**Checklist**
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

**Additional Information**
The fix has been validated locally by setting `window.__starhtml_position_config = {autoUpdate: {elementResize: true}}` globally (equivalent to this change for popover elements) and confirming the dropdown stays anchored as content height changes. Potential side effect: a ResizeObserver is now attached to open popovers, adding a small observer overhead. The existing `checkDOMOscillation` guard handles any potential flip/resize feedback loops.